### PR TITLE
removed the Docker version from the docker-instller role

### DIFF
--- a/ansible/kubernetes/roles/docker-installer/tasks/main.yaml
+++ b/ansible/kubernetes/roles/docker-installer/tasks/main.yaml
@@ -19,7 +19,7 @@
 
 - name: install docker-ce
   package:
-    name: docker-ce-18.09.9
+    name: docker-ce
     state: present
 
 - name: install yum-plugin-versionlock
@@ -27,18 +27,10 @@
     name: yum-plugin-versionlock
     state: present
 
-- name: versionlock docker
-  shell: yum versionlock docker-ce-18.09.9
-  ignore_errors: yes
-
 - name: install docker-ce-cli
   package:
-    name: docker-ce-cli-18.09.9
+    name: docker-ce-cli
     state: present
-
-- name: versionlock docker-ce-cli
-  shell: yum versionlock docker-ce-cli-18.09.9
-  ignore_errors: yes
 
 - name: install containerd.io
   package:


### PR DESCRIPTION
I removed the version lock from Docker as well. As far as I know, we're not limited to a specific docker version anymore. If anyone can think of a reason we should leave this in place, let me know.
