### PR TITLE
CORE-1738: added the RabbitMQ playbook and role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tools for deploying the CyVerse Discovery Environment (DE)
 
 ## Ansible Playbooks
 
-The [Ansible playbooks](playbooks) are primarily used to deploy subsystems used by the DE. Some examples of things that
+The [Ansible playbooks](ansible) are primarily used to deploy subsystems used by the DE. Some examples of things that
 are deployed using Ansible playbooks are OpenLDAP and Kubernetes.
 
 ## Kustomizations

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -10,3 +10,9 @@ cluster.
 The DE uses OpenLDAP using an RFC2307 schema as its user directory by default. If you don't have an existing LDAP
 directory, the [OpenLDAP playbooks](ldap) can be used to create a new one. Note: the DE has not been tested with other
 LDAP schemas.
+
+## RabbitMQ
+
+The DE and CyVerse Data Store both use RabbitMQ as a message bus. The DE uses it for notifications, and the data store
+uses it to push updates to ElasticSearch for indexing. The [RabbitMQ playbooks](rabbitmq) will install RabbitMQ on a
+single node.

--- a/ansible/rabbitmq/main.yml
+++ b/ansible/rabbitmq/main.yml
@@ -1,0 +1,10 @@
+---
+- hosts: amqp-brokers
+  become: true
+  roles:
+    - role: rabbitmq
+      admin_user: "{{ amqp.admin_user }}"
+      admin_password: "{{ amqp.admin_password }}"
+      vhosts:
+        - "{{ amqp.de }}"
+        - "{{ amqp.irods }}"

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/configure.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/configure.yml
@@ -1,0 +1,16 @@
+---
+- name: "create the {{ vhost.vhost }} vhost"
+  rabbitmq_vhost:
+    name: "{{ vhost.vhost }}"
+    state: present
+
+- name: "configure the admin user for the {{ vhost.vhost }} vhost"
+  rabbitmq_user:
+    user: "{{ vhost.user }}"
+    password: "{{ vhost.password }}"
+    vhost: "{{ vhost.vhost }}"
+    state: present
+    configure_priv: .*
+    read_priv: .*
+    write_priv: .*
+    tags: administrator

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
@@ -1,0 +1,37 @@
+---
+- name: install epel-release
+  package:
+    name: epel-release
+    state: latest
+
+- name: install RabbitMQ
+  package:
+    name: rabbitmq-server
+    state: latest
+
+- name: start RabbitMQ
+  systemd:
+    name: rabbitmq-server
+    state: started
+    enabled: yes
+
+- name: enable RabbitMQ management plugin
+  rabbitmq_plugin:
+    names: rabbitmq_management
+    new_only: yes
+    state: enabled
+
+- name: create the admin user
+  rabbitmq_user:
+    user: "{{ admin_user }}"
+    password: "{{ admin_password }}"
+    configure_priv: .*
+    write_priv: .*
+    read_priv: .*
+    tags: administrator
+
+- name: remove the guest user
+  when: admin_user != "guest"
+  rabbitmq_user:
+    user: guest
+    state: absent

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/main.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- include_tasks: install.yml
+- include_tasks: configure.yml
+  loop: "{{ vhosts }}"
+  loop_control:
+    loop_var: vhost


### PR DESCRIPTION
This moves the playbook and role from a private Git repository to a public one.