### PR TITLE
CORE-1738: fix errors in the playbook to install RabbitMQ

### DIFF
--- a/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
@@ -1,8 +1,25 @@
 ---
-- name: install epel-release
+- name: determine whether or not the OS is Amazon Linux 2
+  set_fact:
+    amazon_linux_2: "{{ ansible_distribution == 'Amazon' and ansible_distribution_version == '2' }}"
+
+- debug:
+    var: amazon_linux_2
+
+- name: install epel-release on Amazon Linux 2
+  command:
+    argv:
+      - amazon-linux-extras
+      - install
+      - epel
+      - -y
+  when: "{{ amazon_linux_2 }}"
+
+- name: install epel-release on CentOS or Rocky
   package:
     name: epel-release
     state: latest
+  when: "{{ not amazon_linux_2 }}"
 
 - name: install RabbitMQ
   package:

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
@@ -10,6 +10,7 @@
       - install
       - epel
       - -y
+    creates: /etc/yum.repos.d/epel.repo
   when: amazon_linux_2
 
 - name: install epel-release on CentOS or Rocky
@@ -29,7 +30,17 @@
     state: started
     enabled: yes
 
-- name: enable RabbitMQ management plugin
+- name: list explicitly enabled RabbitMQ plugins matching `rabbitmq_management`
+  command:
+    argv:
+      - rabbitmq-plugins
+      - list
+      - -E
+      - rabbitmq_management
+  register: mgmt_plugin_listing
+  changed_when: false
+
+- name: enable the RabbitMQ management plugin
   block:
     - command:
         argv:
@@ -40,6 +51,7 @@
         name: rabbitmq-server
         state: restarted
         enabled: yes
+  when: not mgmt_plugin_listing is search("\srabbitmq_management\s")
 
 - name: create the admin user
   rabbitmq_user:

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
@@ -3,9 +3,6 @@
   set_fact:
     amazon_linux_2: "{{ ansible_distribution == 'Amazon' and ansible_distribution_version == '2' }}"
 
-- debug:
-    var: amazon_linux_2
-
 - name: install epel-release on Amazon Linux 2
   command:
     argv:

--- a/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
+++ b/ansible/rabbitmq/roles/rabbitmq/tasks/install.yml
@@ -13,13 +13,13 @@
       - install
       - epel
       - -y
-  when: "{{ amazon_linux_2 }}"
+  when: amazon_linux_2
 
 - name: install epel-release on CentOS or Rocky
   package:
     name: epel-release
     state: latest
-  when: "{{ not amazon_linux_2 }}"
+  when: not amazon_linux_2
 
 - name: install RabbitMQ
   package:
@@ -33,10 +33,16 @@
     enabled: yes
 
 - name: enable RabbitMQ management plugin
-  rabbitmq_plugin:
-    names: rabbitmq_management
-    new_only: yes
-    state: enabled
+  block:
+    - command:
+        argv:
+          - rabbitmq-plugins
+          - enable
+          - rabbitmq_management
+    - systemd:
+        name: rabbitmq-server
+        state: restarted
+        enabled: yes
 
 - name: create the admin user
   rabbitmq_user:


### PR DESCRIPTION
Doing a merge every time I had to make a change for testing was untenable, so I ended up cloning my fork of this repository on the bastion host that I was using instead.

The problem with enabling the RabbitMQ management plugin must have been a version problem. It was complaning about the `--online` module not being found. Obviously, this was supposed to be a command-line option rather than a module name. I ended up replacing the use of the `rabbitmq_plugin` module with a block consisting of a couple of subtasks.
