### PR TITLE
HAProxy

### DIFF
--- a/ansible/haproxy/README.md
+++ b/ansible/haproxy/README.md
@@ -1,0 +1,3 @@
+# HAProxy deployment playbooks
+
+These playbooks can be used to install and configure HAProxy to serve as a reverse proxy for DE-related services including the UI.

--- a/ansible/haproxy/README.md
+++ b/ansible/haproxy/README.md
@@ -1,3 +1,26 @@
 # HAProxy deployment playbooks
 
 These playbooks can be used to install and configure HAProxy to serve as a reverse proxy for DE-related services including the UI.
+
+## Playbooks
+
+### main.yml
+
+This playbook installs and configures HAProxy to forward traffic to the DE. This does not install the SSL certificates; for that use the `tls-certs` playbooks instead, whose folder should be a directory above this README.
+
+## Inventory Setup
+
+```
+[de_proxy]
+proxy-node.example.org
+
+[k8s_de_workers]
+k8s-node-1.example.org
+k8s-node-2.example.org
+```
+
+The `de_proxy` group should contain the server set up as the proxy node. DNS for the environment's main access point should point to this server. The `k8s_de_workers` node should be set up as for the kubernetes roles, and should contain the nodes on which the DE might be running (nodes that will have the appropriate NodePorts set up to proxy to).
+
+## Group Variable Setup
+
+This playbook only needs one group variable, to set the external DNS name that should forward to Sonora, under the name `external_dns_name`.

--- a/ansible/haproxy/main.yml
+++ b/ansible/haproxy/main.yml
@@ -1,0 +1,6 @@
+- name: Set up HAProxy for the DE
+  hosts: de_proxy
+  become: true
+  gather_facts: false
+  roles:
+    - role: haproxy

--- a/ansible/haproxy/roles/haproxy/defaults/main.yml
+++ b/ansible/haproxy/roles/haproxy/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+external_dns_name: de.example.org

--- a/ansible/haproxy/roles/haproxy/handlers/main.yml
+++ b/ansible/haproxy/roles/haproxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart haproxy
+  ansible.builtin.service:
+    name: haproxy
+    state: restarted

--- a/ansible/haproxy/roles/haproxy/tasks/main.yml
+++ b/ansible/haproxy/roles/haproxy/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+- name: install | apt install haproxy
+  apt:
+    update_cache: true
+    pkg:
+      - "haproxy"
+    state: present
+
+- name: configure | download dhparam
+  ansible.builtin.get_url:
+    url: https://ssl-config.mozilla.org/ffdhe2048.txt
+    dest: /etc/ssl/dhparam
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: configure | template config
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - restart haproxy

--- a/ansible/haproxy/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/haproxy/roles/haproxy/templates/haproxy.cfg.j2
@@ -36,7 +36,7 @@ frontend http2-ssl
     bind *:443 ssl crt /etc/ssl/cyverse.combined alpn h2,http/1.1
     redirect scheme https code 301 if !{ ssl_fc }
 
-    acl de hdr(host) -i qa.cyverse.org
+    acl de hdr(host) -i {{ external_dns_name }}
     acl oldpath path_beg -i /anon-files/ /dl/ /de/agave-cb /dataone-node /terrain /de/websocket
 
     # HSTS (63072000 seconds)

--- a/ansible/haproxy/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/haproxy/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,68 @@
+global
+    log         127.0.0.1 local2
+
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+
+    ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305
+    ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+
+    ssl-default-server-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305
+    ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    ssl-default-server-options no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets
+
+    # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /etc/ssl/dhparam
+    ssl-dh-param-file /etc/ssl/dhparam
+
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option                  redispatch
+    retries                 3
+    timeout http-request    10s
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout tunnel          86400s
+    timeout http-keep-alive 10s
+    timeout check           10s
+    maxconn                 3000
+
+frontend http2-ssl
+    bind *:443 ssl crt /etc/ssl/cyverse.combined alpn h2,http/1.1
+    redirect scheme https code 301 if !{ ssl_fc }
+
+    acl de hdr(host) -i qa.cyverse.org
+    acl oldpath path_beg -i /anon-files/ /dl/ /de/agave-cb /dataone-node /terrain /de/websocket
+
+    # HSTS (63072000 seconds)
+    http-response set-header Strict-Transport-Security max-age=63072000
+
+    use_backend sonora if de !oldpath
+    default_backend de-nginx
+
+backend sonora
+    option log-health-checks
+    option forwardfor
+
+    http-request add-header X-Forwarded-Proto https
+
+    balance roundrobin
+    {% for svr in groups['k8s_de_workers'] %}
+    server {{ svr }} {{ svr }}:31346 check inter 5000
+    {% endfor %}
+
+backend de-nginx
+    option log-health-checks
+    option forwardfor
+
+    http-request add-header X-Forwarded-Proto https
+
+    balance roundrobin
+    {% for svr in groups['k8s_de_workers'] %}
+    server {{ svr }} {{ svr }}:31342 check inter 5000
+    {% endfor %}

--- a/ansible/tls-certs/main.yml
+++ b/ansible/tls-certs/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Copy TLS cert to haproxy host
+  hosts: de_proxy 
+  become: true
+  gather_facts: false
+  vars:
+    combined_cert_src: /etc/ssl/cyverse.combined
+  tasks:
+    - name: copy cert
+      ansible.builtin.copy:
+        src: "{{ combined_cert_src }}"
+        dest: "/etc/ssl/cyverse.combined"
+        group: root
+        owner: root
+        mode: 0600


### PR DESCRIPTION
This should, hopefully, add a simple HAProxy setup for the DE. Some things this doesn't handle: redirecting old URLs to the current one (e.g. newqa -> qa), and currently hardcodes qa as the URL. I'll work on those (at least the latter), but wanted to get the structure of it up for potential review this week.