### PR TITLE
Add ingress for agave-cb

### DIFF
--- a/ansible/kubernetes/roles/common/defaults/main.yml
+++ b/ansible/kubernetes/roles/common/defaults/main.yml
@@ -5,6 +5,8 @@ dbms_connection_pass: Ch@ng3M3
 ns: qa
 vice_ns: vice-apps
 
+de_hostname: de.cyverse.org
+
 force_reinstall: false
 
 k3s_token: K3sT0k3n

--- a/ansible/kubernetes/roles/ingresses/tasks/main.yml
+++ b/ansible/kubernetes/roles/ingresses/tasks/main.yml
@@ -42,6 +42,34 @@
       path: /terrain
       service: terrain
 
+- name: Add agave-callback ingress
+  delegate_to: localhost
+  environment:
+    KUBECONFIG: "{{ lookup('env', 'KUBECONFIG') }}"
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: agave-callback
+        namespace: "{{ ns }}"
+        annotations:
+          traefik.ingress.kubernetes.io/rewrite-target: /callbacks/agave-job
+      spec:
+        ingressClass: traefik
+        rules:
+          - host: de.cyverse.org
+            http:
+              paths:
+                - path: /de/agave-cb
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: apps
+                      port:
+                        number: 80
+
 - name: Add ingresses
   delegate_to: localhost
   environment:

--- a/ansible/kubernetes/roles/ingresses/tasks/main.yml
+++ b/ansible/kubernetes/roles/ingresses/tasks/main.yml
@@ -21,7 +21,7 @@
       spec:
         ingressClass: traefik
         rules:
-          - host: de.cyverse.org
+          - host: "{{ de_hostname }}"
             http:
               paths:
                 - path: "{{ item.path }}"
@@ -59,7 +59,7 @@
       spec:
         ingressClass: traefik
         rules:
-          - host: de.cyverse.org
+          - host: "{{ de_hostname }}"
             http:
               paths:
                 - path: /de/agave-cb
@@ -85,7 +85,7 @@
       spec:
         ingressClass: traefik
         rules:
-          - host: de.cyverse.org
+          - host: "{{ de_hostname }}"
             http:
               paths:
                 - path: /job


### PR DESCRIPTION
Adds an ingress for the /de/agave-cb path. Rewrites the path to /callbacks/agave-job, which should get used when passing the request along to the apps service. 