### PR TITLE
CORE-2074: remove time zone volume mounts.

### DIFF
--- a/ansible/roles/grouper_init/tasks/main.yml
+++ b/ansible/roles/grouper_init/tasks/main.yml
@@ -43,15 +43,6 @@
             namespace: "{{ ns }}"
           spec:
             volumes:
-              - name: localtime
-                hostPath:
-                  path: /etc/localtime
-              - name: timezone
-                configMap:
-                  name: timezone
-                  items:
-                    - key: timezone
-                      path: timezone
               - name: grouper-configs
                 secret:
                   secretName: grouper-configs
@@ -84,13 +75,13 @@
                 tty: true
                 command:
                   - sh
+                env:
+                  - name: TZ
+                    valueFrom:
+                      configMapKeyRef:
+                        name: timezone
+                        key: timezone
                 volumeMounts:
-                  - name: localtime
-                    mountPath: /etc/localtime
-                    readOnly: true
-                  - name: timezone
-                    mountPath: /etc/timezone
-                    readOnly: true
                   - name: grouper-configs
                     mountPath: /etc/grouper
                     readOnly: true
@@ -281,15 +272,6 @@
                     topologyKey: kubernetes.io/hostname
             restartPolicy: Always
             volumes:
-              - name: localtime
-                hostPath:
-                  path: /etc/localtime
-              - name: timezone
-                configMap:
-                  name: timezone
-                  items:
-                    - key: timezone
-                      path: timezone
               - name: realm-config
                 secret:
                   secretName: grouper-configs
@@ -344,14 +326,6 @@
                 command: ["/bin/bash"]
                 args: ["-c", "gsh -loader"]
                 volumeMounts:
-                  - name: localtime
-                    mountPath: /etc/localtime
-                    readOnly: true
-
-                  - name: timezone
-                    mountPath: /etc/timezone
-                    subPath: timezone
-
                   - name: realm-config
                     mountPath: /usr/src/app/realm.properties
                     subPath: realm.properties
@@ -360,6 +334,12 @@
                     mountPath: /etc/grouper
                     readOnly: true
                 env:
+                  - name: TZ
+                    valueFrom:
+                      configMapKeyRef:
+                        name: timezone
+                        key: timezone
+
                   - name: JAVA_TOOL_OPTIONS
                     valueFrom:
                       configMapKeyRef:
@@ -409,15 +389,6 @@
                     topologyKey: kubernetes.io/hostname
             restartPolicy: Always
             volumes:
-              - name: localtime
-                hostPath:
-                  path: /etc/localtime
-              - name: timezone
-                configMap:
-                  name: timezone
-                  items:
-                    - key: timezone
-                      path: timezone
               - name: realm-config
                 secret:
                   secretName: grouper-configs
@@ -471,14 +442,6 @@
                     ephemeral-storage: "1Gi"
                 args: ["ws"]
                 volumeMounts:
-                  - name: localtime
-                    mountPath: /etc/localtime
-                    readOnly: true
-
-                  - name: timezone
-                    mountPath: /etc/timezone
-                    subPath: timezone
-
                   - name: realm-config
                     mountPath: /usr/src/app/realm.properties
                     subPath: realm.properties
@@ -487,6 +450,11 @@
                     mountPath: /etc/grouper
                     readOnly: true
                 env:
+                  - name: TZ
+                    valueFrom:
+                      configMapKeyRef:
+                        name: timezone
+                        key: timezone
                   - name: WEBAPPS_HOME
                     value: "/usr/src/app"
                   - name: JAVA_TOOL_OPTIONS

--- a/ansible/roles/k8s_de_reqs/tasks/main.yml
+++ b/ansible/roles/k8s_de_reqs/tasks/main.yml
@@ -332,27 +332,9 @@
                                 - unleash
                         topologyKey: kubernetes.io/hostname
                 restartPolicy: Always
-                volumes:
-                  - name: localtime
-                    hostPath:
-                      path: /etc/localtime
-                  - name: timezone
-                    configMap:
-                      name: timezone
-                      items:
-                        - key: timezone
-                          path: timezone
                 containers:
                   - name: unleash
                     image: unleashorg/unleash-server:4.0.5
-                    volumeMounts:
-                      - name: localtime
-                        mountPath: /etc/localtime
-                        readOnly: true
-
-                      - name: timezone
-                        mountPath: /etc/timezone
-                        subPath: timezone
                     env:
                       - name: DATABASE_HOST
                         valueFrom:

--- a/ansible/roles/k8s_de_reqs/tasks/main.yml
+++ b/ansible/roles/k8s_de_reqs/tasks/main.yml
@@ -233,26 +233,9 @@
                                 - local-exim
                         topologyKey: kubernetes.io/hostname
                 restartPolicy: Always
-                volumes:
-                  - name: localtime
-                    hostPath:
-                      path: /etc/localtime
-                  - name: timezone
-                    configMap:
-                      name: timezone
-                      items:
-                        - key: timezone
-                          path: timezone
                 containers:
                   - name: local-exim
                     image: "discoenv/exim-sender@sha256:af3543b26caba4407a3c6255721ca1cc02da63cd0886025262a6d8d11f6a1d96"
-                    volumeMounts:
-                      - name: localtime
-                        mountPath: /etc/localtime
-                        readOnly: true
-                      - name: timezone
-                        mountPath: /etc/timezone
-                        subPath: timezone
                     resources:
                       requests:
                         cpu: "5m"
@@ -261,6 +244,11 @@
                         cpu: "100m"
                         memory: "256Mi"
                     env:
+                      - name: TZ
+                        valueFrom:
+                          configMapKeyRef:
+                            name: timezone
+                            key: timezone
                       - name: DE_ENV
                         value: "{{ ns }}"
                       - name: PRIMARY_HOST


### PR DESCRIPTION
In most cases the container images have `tzdata` installed, so setting the `TZ` environment variable is enough to specify the time zone. The container image for Unleash doesn't have `tzdata` installed, so we're simply not going to set the time zone. It won't be too much of a hassle to have the Unleash logs in UTC rather than the local time zone.