### PR TITLE
CORE-2117: two additional changes for Postgres 18 compatibility

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -299,7 +299,7 @@ notifications_db_version: main
 metadata_db_version: main
 mgmt_version: main
 qms_version: main
-portal_version: master
+portal_version: main
 de_db_name: de
 notifications_db_name: notifications
 metadata_db_name: metadata
@@ -318,8 +318,7 @@ dbms_allowed_local_addresses:
   - "192.168.0.0/16"
 dbms_allowed_remote_addresses: []
 encoding: UTF8
-lc_collate: en_US.UTF-8
-lc_ctype: en_US.UTF-8
+icu_locale: en-US
 template: template0
 cleanup: true
 migrate: true

--- a/ansible/roles/postgresql_init/tasks/de.yml
+++ b/ansible/roles/postgresql_init/tasks/de.yml
@@ -11,8 +11,8 @@
         name: "{{ item }}"
         owner: "{{ dbms_connection_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       loop:
         - "{{de_db_name}}"

--- a/ansible/roles/postgresql_init/tasks/grouper.yml
+++ b/ansible/roles/postgresql_init/tasks/grouper.yml
@@ -21,7 +21,7 @@
         name: "{{ grouper_db_name }}"
         owner: "{{ grouper_connection_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs

--- a/ansible/roles/postgresql_init/tasks/harbor.yml
+++ b/ansible/roles/postgresql_init/tasks/harbor.yml
@@ -23,8 +23,8 @@
         name: "{{ harbor_core_db_name }}"
         owner: "{{ harbor_database_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs
 
@@ -37,8 +37,8 @@
         name: "{{ harbor_clair_db_name }}"
         owner: "{{ harbor_database_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs
 
@@ -51,8 +51,8 @@
         name: "{{ harbor_notary_server_db_name }}"
         owner: "{{ harbor_database_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs
 
@@ -65,7 +65,7 @@
         name: "{{ harbor_notary_signer_db_name }}"
         owner: "{{ harbor_database_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs

--- a/ansible/roles/postgresql_init/tasks/keycloak.yml
+++ b/ansible/roles/postgresql_init/tasks/keycloak.yml
@@ -21,7 +21,7 @@
         name: "{{ keycloak_db_name }}"
         owner: "{{ keycloak_db_username }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs

--- a/ansible/roles/postgresql_init/tasks/portal.yml
+++ b/ansible/roles/postgresql_init/tasks/portal.yml
@@ -21,8 +21,8 @@
         name: "{{ portal_db_name }}"
         owner: "{{ portal_db_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs
 

--- a/ansible/roles/postgresql_init/tasks/qms.yml
+++ b/ansible/roles/postgresql_init/tasks/qms.yml
@@ -10,8 +10,8 @@
         name: "{{ qms_db_name }}"
         owner: "{{ dbms_connection_user }}"
         encoding: "{{ encoding }}"
-        lc_collate: "{{ lc_collate }}"
-        lc_ctype: "{{ lc_ctype }}"
+        locale_provider: "icu"
+        icu_locale: "{{ icu_locale }}"
         template: "{{ template }}"
       when: create_dbs is defined and create_dbs
 

--- a/ansible/roles/postgresql_init/tasks/unleash.yml
+++ b/ansible/roles/postgresql_init/tasks/unleash.yml
@@ -9,7 +9,7 @@
     name: "{{ unleash_db_name }}"
     owner: "{{ dbms_connection_user }}"
     encoding: "{{ encoding }}"
-    lc_collate: "{{ lc_collate }}"
-    lc_ctype: "{{ lc_ctype }}"
+    locale_provider: "icu"
+    icu_locale: "{{ icu_locale }}"
     template: "{{ template }}"
   when: create_dbs is defined and create_dbs and unleash is defined and unleash


### PR DESCRIPTION
This PR includes two changes:
- The main branch of the `portal2` repository is now `main`.
- The `libc` collations aren't available by default, so we're going to use the `icu` collations instead.
