### PR TITLE
CORE-2119: migrate VICE to the Gateway API

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -636,6 +636,9 @@ keycloak_cpu_limit: "200m"
 keycloak_memory_limit: "2Gi"
 keycloak_ephemeral_storage_limit: "2Gi"
 
+# Gateway provider configuration
+gateway_provider: "traefik"
+
 # Traefik configuration
 traefik_namespace: "traefik"
 traefik_ca_name: "traefik-selfsigned-ca"

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -160,6 +160,15 @@ de_tls_cert_name: "de-tls"
 de_tls_cert_duration: "2160h"
 de_tls_cert_renew_before: "240h"
 
+# VICE TLS settings
+vice_tls_ca_name: "vice-selfsigned-ca"
+vice_tls_ca_duration: "8766h"
+vice_tls_ca_renew_before: "240h"
+vice_tls_issuer_name: "vice-ca-issuer"
+vice_tls_cert_name: "vice-tls"
+vice_tls_cert_duration: "2160h"
+vice_tls_cert_renew_before: "240h"
+
 # Docker related settings
 docker_tag: latest
 docker_trusted_registries:

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -638,6 +638,7 @@ keycloak_ephemeral_storage_limit: "2Gi"
 
 # Gateway provider configuration
 gateway_provider: "traefik"
+gateway_class_name: "traefik"
 
 # Traefik configuration
 traefik_namespace: "traefik"

--- a/ansible/roles/k8s_de_reqs/tasks/de_namespaces.yml
+++ b/ansible/roles/k8s_de_reqs/tasks/de_namespaces.yml
@@ -184,3 +184,42 @@
             kind: ClusterRole
             name: admin
             apiGroup: rbac.authorization.k8s.io
+
+    - name: create the httproute-admin cluster role
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: httproute-admin
+          rules:
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+
+    - name: create the app-exposer httproute admin cluster role binding
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: app-exposer-httproute-admin
+          subjects:
+            - kind: ServiceAccount
+              namespace: "{{ ns }}"
+              name: app-exposer
+          roleRef:
+            kind: ClusterRole
+            name: httproute-admin
+            apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/k8s_de_reqs/tasks/de_namespaces.yml
+++ b/ansible/roles/k8s_de_reqs/tasks/de_namespaces.yml
@@ -3,12 +3,16 @@
   environment:
     KUBECONFIG: "{{ lookup('env', 'KUBECONFIG') }}"
   block:
-    - name: create the namespaces for the services
+    - name: create the namespaces for the DE and VICE
       kubernetes.core.k8s:
-        name: "{{ item }}"
-        state: present
-        kind: namespace
         api_version: v1
+        state: present
+        definition:
+          kind: Namespace
+          metadata:
+            name: "{{ item }}"
+            labels:
+              has-vice-routes: "true"
       loop:
         - "{{ ns }}"
         - "{{ vice_ns }}"

--- a/ansible/roles/k8s_de_reqs/tasks/main.yml
+++ b/ansible/roles/k8s_de_reqs/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - ansible.builtin.include_tasks: traefik.yml
+  when: gateway_provider == "traefik"
 - ansible.builtin.include_tasks: ingress_nginx.yml
 - ansible.builtin.include_tasks: de_namespaces.yml
 - ansible.builtin.include_tasks: local_exim.yml

--- a/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
+++ b/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
@@ -258,7 +258,6 @@
                 timeouts:
                   request: "24h"
                   backendRequest: "24h"
-      register: discoenv_routes_defined
       when: gateway_provider == "traefik"
 
     - name: define the routes for the DE when provider-specific customizations aren't needed.
@@ -330,7 +329,8 @@
                 timeouts:
                   request: "24h"
                   backendRequest: "24h"
-      when: not discoenv_routes_defined
+      # Add new providers to this list as providers are added so that other provider-specific routes aren't overwritten.
+      when: gateway_provider not in ["traefik"]
 
     - name: define the gateway for the user portal
       kubernetes.core.k8s:

--- a/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
+++ b/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
@@ -270,3 +270,120 @@
               - backendRefs:
                   - name: user-portal
                     port: 3000
+
+    - name: define the self-signed CA certificate for VICE
+      kubernetes.core.k8s:
+        name: "{{ vice_tls_ca_name }}"
+        namespace: "{{ ns }}"
+        state: present
+        definition:
+          apiVersion: cert-manager.io/v1
+          kind: Certificate
+          metadata:
+            name: "{{ vice_tls_ca_name }}"
+          spec:
+            isCA: true
+            commonName: "{{ vice_tls_ca_name }}"
+            secretName: "{{ vice_tls_ca_name }}"
+            duration: "{{ vice_tls_ca_duration }}"
+            renewBefore: "{{ vice_tls_ca_renew_before }}"
+            privateKey:
+              algorithm: ECDSA
+              size: 256
+            issuerRef:
+              name: default-cluster-issuer
+              kind: ClusterIssuer
+              group: cert-manager.io
+
+    - name: create the certificate issuer for VICE
+      kubernetes.core.k8s:
+        name: "{{ vice_tls_issuer_name }}"
+        namespace: "{{ ns }}"
+        state: present
+        definition:
+          apiVersion: cert-manager.io/v1
+          kind: Issuer
+          metadata:
+            name: "{{ vice_tls_issuer_name }}"
+          spec:
+            ca:
+              secretName: "{{ vice_tls_ca_name }}"
+
+    - name: create the TLS certificate for VICE
+      kubernetes.core.k8s:
+        name: "{{ vice_tls_cert_name }}"
+        namespace: "{{ ns }}"
+        state: present
+        definition:
+          apiVersion: cert-manager.io/v1
+          kind: Certificate
+          metadata:
+            name: "{{ vice_tls_cert_name }}"
+          spec:
+            secretName: "{{ vice_tls_cert_name }}"
+            duration: "{{ vice_tls_cert_duration }}"
+            renewBefore: "{{ vice_tls_cert_renew_before }}"
+            issuerRef:
+              name: "{{ vice_tls_issuer_name }}"
+              kind: Issuer
+            commonName: "*.{{ ns }}.svc.cluster.local"
+            dnsNames:
+              - localhost
+              - "{{ vice_wildcard_fqdn }}"
+
+    - name: define the gateway for VICE
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: vice
+            namespace: "{{ ns }}"
+          spec:
+            gatewayClassName: traefik
+            listeners:
+              - allowedRoutes:
+                  namespaces:
+                    from: Selector
+                    selector:
+                      matchLabels:
+                        has-vice-routes: "true"
+                hostname: "{{ vice_wildcard_fqdn }}"
+                name: vice-http
+                port: 8000
+                protocol: HTTP
+              - allowedRoutes:
+                  namespaces:
+                    from: Selector
+                    selector:
+                      matchLabels:
+                        has-vice-routes: "true"
+                hostname: "{{ vice_wildcard_fqdn }}"
+                name: vice-https
+                port: 8443
+                protocol: HTTPS
+                tls:
+                  certificateRefs:
+                    - kind: Secret
+                      group: ""
+                      name: "{{ vice_tls_cert_name }}"
+
+    - name: define the default route for VICE
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: vice-default-route
+            namespace: "{{ ns }}"
+          spec:
+            hostnames:
+              - "{{ vice_wildcard_fqdn }}"
+            parentRefs:
+              - name: vice
+            rules:
+              - backendRefs:
+                  - name: vice-default-backend
+                    port: 80

--- a/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
+++ b/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
@@ -73,7 +73,7 @@
             name: discoenv
             namespace: "{{ ns }}"
           spec:
-            gatewayClassName: traefik
+            gatewayClassName: "{{ gateway_class_name }}"
             listeners:
               - hostname: "{{ de_hostname }}"
                 name: discoenv-http
@@ -119,6 +119,7 @@
                 - "Range"
               accessControlAllowCredentials: true
               accessControlMaxAge: 86400
+      when: gateway_provider == "traefik"
 
     - name: define the CORS middleware for VICE
       kubernetes.core.k8s:
@@ -150,8 +151,9 @@
                 - "Range"
               accessControlAllowCredentials: true
               accessControlMaxAge: 86400
+      when: gateway_provider == "traefik"
 
-    - name: define the routes for the DE
+    - name: define the routes for the DE when the gateway provider is Traefik
       kubernetes.core.k8s:
         state: present
         definition:
@@ -256,6 +258,79 @@
                 timeouts:
                   request: "24h"
                   backendRequest: "24h"
+      register: discoenv_routes_defined
+      when: gateway_provider == "traefik"
+
+    - name: define the routes for the DE when provider-specific customizations aren't needed.
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: discoenv-routes
+            namespace: "{{ ns }}"
+          spec:
+            hostnames:
+              - "{{ de_hostname }}"
+            parentRefs:
+              - name: discoenv
+            rules:
+              - backendRefs:
+                  - name: kifshare
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /anon-files
+                timeouts:
+                  request: "24h"
+                  backendRequest: "24h"
+              - backendRefs:
+                  - name: kifshare
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /dl
+                timeouts:
+                  request: "24h"
+                  backendRequest: "24h"
+              - backendRefs:
+                  - name: terrain
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /terrain
+                timeouts:
+                  request: "24h"
+                  backendRequest: "24h"
+              - backendRefs:
+                  - name: job-status-listener
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /job
+              - backendRefs:
+                  - name: formation
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /formation
+              - backendRefs:
+                  - name: sonora
+                    port: 80
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                timeouts:
+                  request: "24h"
+                  backendRequest: "24h"
+      when: not discoenv_routes_defined
 
     - name: define the gateway for the user portal
       kubernetes.core.k8s:
@@ -267,7 +342,7 @@
             name: portal
             namespace: "{{ ns }}"
           spec:
-            gatewayClassName: traefik
+            gatewayClassName: "{{ gateway_class_name }}"
             listeners:
               - hostname: "{{ portal_hostname }}"
                 name: portal-http
@@ -372,7 +447,7 @@
             name: vice
             namespace: "{{ ns }}"
           spec:
-            gatewayClassName: traefik
+            gatewayClassName: "{{ gateway_class_name }}"
             listeners:
               - allowedRoutes:
                   namespaces:

--- a/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
+++ b/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
@@ -89,7 +89,7 @@
                       group: ""
                       name: "{{ de_tls_cert_name }}"
 
-    - name: define the CORS middleware
+    - name: define the CORS middleware for the DE
       kubernetes.core.k8s:
         state: present
         definition:
@@ -98,6 +98,37 @@
           metadata:
             name: discoenv-cors-headers
             namespace: "{{ ns }}"
+          spec:
+            headers:
+              accessControlAllowOriginList:
+                - "*"
+              accessControlAllowMethods:
+                - "GET"
+                - "POST"
+                - "OPTIONS"
+              accessControlAllowHeaders:
+                - "Authorization"
+                - "DNT"
+                - "Keep-Alive"
+                - "User-Agent"
+                - "X-Requested-With"
+                - "If-Modified-Since"
+                - "Cache-Control"
+                - "Content-Type"
+                - "Content-Range"
+                - "Range"
+              accessControlAllowCredentials: true
+              accessControlMaxAge: 86400
+
+    - name: define the CORS middleware for VICE
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: traefik.io/v1alpha1
+          kind: Middleware
+          metadata:
+            name: vice-cors-headers
+            namespace: "{{ vice_ns }}"
           spec:
             headers:
               accessControlAllowOriginList:

--- a/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
+++ b/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml
@@ -138,6 +138,12 @@
               - backendRefs:
                   - name: kifshare
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix
@@ -148,6 +154,12 @@
               - backendRefs:
                   - name: kifshare
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix
@@ -158,6 +170,12 @@
               - backendRefs:
                   - name: terrain
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix
@@ -168,6 +186,12 @@
               - backendRefs:
                   - name: job-status-listener
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix
@@ -175,6 +199,12 @@
               - backendRefs:
                   - name: formation
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix
@@ -182,6 +212,12 @@
               - backendRefs:
                   - name: sonora
                     port: 80
+                filters:
+                  - type: ExtensionRef
+                    extensionRef:
+                      group: traefik.io
+                      kind: Middleware
+                      name: discoenv-cors-headers
                 matches:
                   - path:
                       type: PathPrefix


### PR DESCRIPTION
This PR makes the following changes.

- [x] Adds the CORS middleware to the `discoenv` HTTPRoutes.
- [x] Adds labels to the DE and VICE namespaces indicating that they can both contain HTTPRoutes that use the `vice` gateway.
- [x] Adds tasks that can be used to create the `vice` gateway and the default route for it.
- [x] Adds a group variable to indicate which gateway provider is being used. For the time being, only Traefik is supported, but we may need to support additional providers in the future.
- [x] Makes installing the Traefik gateway provider optional based on the `gateway_provider` group variable being set to `traefik`.
