### PR TITLE
update the common JVM options for our services

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -447,9 +447,9 @@ jobs_data_transfer_image: harbor.cyverse.org/de/porklock
 jobs_data_transfer_tag: latest
 
 # JVM options used by the DE services
-jvm_opts_high: "-Xmx1G -Dlog4j2.formatMsgNoLookups=true"
-jvm_opts_low: "-Xmx512M -Dlog4j2.formatMsgNoLookups=true"
-jvm_opts_ui: "-Xmx1G -Djava.net.preferIPv4Stack=true"
+jvm_opts_high: "-XX:MaxRAMPercentage=70 -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Dlog4j2.formatMsgNoLookups=true"
+jvm_opts_medium: "-XX:MaxRAMPercentage=60 -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Dlog4j2.formatMsgNoLookups=true"
+jvm_opts_low: "-Xms128m -Xmx128m -XX:+UseSerialGC -XX:+ExitOnOutOfMemoryError -Dlog4j2.formatMsgNoLookups=true"
 
 # PGP settings
 pgp_key_password: replace_me

--- a/ansible/roles/service_configurations/tasks/main.yml
+++ b/ansible/roles/service_configurations/tasks/main.yml
@@ -171,6 +171,6 @@
             namespace: "{{ ns }}"
           data:
             low: "{{ jvm_opts_low }}"
+            medium: "{{ jvm_opts_medium }}"
             high: "{{ jvm_opts_high }}"
-            ui: "{{ jvm_opts_ui }}"
       when: load_configs is undefined or (load_configs | bool)


### PR DESCRIPTION
This is a companion pull request to https://github.com/cyverse-de/clockwork/pull/13. This change removes the old UI JVM options, adds a new `medium` setting, and updates the options for the other two existing settings.