### PR TITLE
CORE-2156: HAProxy + firewall detection (3/6)

### DIFF
--- a/ansible/example/inventory/group_vars/all.yaml
+++ b/ansible/example/inventory/group_vars/all.yaml
@@ -346,7 +346,43 @@
 
 
 # =====================================================================
-# Phase 3: Kubernetes Node Preparation
+# Phase 3: HAProxy Load Balancer
+# =====================================================================
+# Variables consulted by `kubernetes.yml --tags haproxy` (installs
+# HAProxy on the `k8s_api_proxy` hosts and load-balances the Kubernetes
+# API, konnectivity, and controller-join ports across the hosts in the
+# `k8s_controllers` inventory group).
+#
+# Run this phase before the `create-cluster` pass — the controllers
+# register with each other through the load balancer, so it has to be in
+# place first.
+#
+# This phase runs the `haproxy` and `k8s_haproxy` roles. The base
+# `haproxy` role's configuration is fully static; only `k8s_haproxy`
+# consults the variable below. The controller backends are taken from
+# the `k8s_controllers` inventory group, not from a variable.
+#
+# The variable below has a default in `roles/common/defaults/main.yml`.
+# It is commented out so the file is a no-op as shipped — uncomment the
+# line to override the default.
+# =====================================================================
+
+
+# ---------------------------------------------------------------------
+# Kubernetes API load balancing
+# ---------------------------------------------------------------------
+
+# TCP port the Kubernetes (k0s) API server listens on. HAProxy binds it
+# on the `k8s_api_proxy` hosts and balances it across every host in the
+# `k8s_controllers` group. Keep it in sync with the value used by the
+# `create-cluster` pass. The konnectivity (8132) and controller-join
+# (9443) ports are fixed and not configurable here.
+# Default: "6443"
+# k8s_api_port: "6443"
+
+
+# =====================================================================
+# Phase 4: Kubernetes Node Preparation
 # =====================================================================
 # Variables consulted by `kubernetes.yml --tags prep-nodes` (GPU drivers,
 # timezone, base node prep, firewalld, NVIDIA container toolkit).

--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -30,4 +30,4 @@
     group: root
     mode: "0644"
   notify:
-    - restart haproxy
+    - Restart haproxy

--- a/ansible/roles/k8s_firewalld/tasks/main.yml
+++ b/ansible/roles/k8s_firewalld/tasks/main.yml
@@ -1,10 +1,22 @@
 ---
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Set firewall fact
+  ansible.builtin.set_fact:
+    active_firewall: >-
+      {% if ansible_facts.services['firewalld.service'] is defined
+          and ansible_facts.services['firewalld.service'].state == 'running' %}firewalld
+      {%- elif ansible_facts.services['ufw.service'] is defined
+            and ansible_facts.services['ufw.service'].state == 'running' %}ufw
+      {%- else %}none{% endif %}
+
 - name: Start and enable firewalld
   ansible.builtin.service:
     name: firewalld
     state: started
     enabled: true
-  when: ansible_os_family == "RedHat"
+  when: active_firewall == "firewalld"
 
 - name: Open the ports
   ansible.posix.firewalld:
@@ -24,7 +36,7 @@
     - "30000-32767/tcp" # nodeports
     - "30000-32767/udp" # nodeports
   notify: Reload firewalld
-  when: ansible_os_family == "RedHat"
+  when: active_firewall == "firewalld"
 
 - name: Remove trusted subnets from public zone
   ansible.builtin.command: "firewall-cmd --zone=public --remove-source={{ item }} --permanent"
@@ -32,7 +44,7 @@
     - 10.42.0.0/16 # k3s pods
     - 10.43.0.0/16 # k3s services
   notify: Reload firewalld
-  when: ansible_os_family == "RedHat"
+  when: active_firewall == "firewalld"
 
 - name: Open trusted subnets
   ansible.builtin.command: "firewall-cmd --zone=trusted --add-source={{ item }} --permanent"
@@ -40,7 +52,7 @@
     - 10.42.0.0/16 # k3s pods
     - 10.43.0.0/16 # k3s services
   notify: Reload firewalld
-  when: ansible_os_family == "RedHat"
+  when: active_firewall == "firewalld"
 
 - name: Open ports via ufw on Debian systems
   community.general.ufw:
@@ -64,7 +76,7 @@
       proto: tcp
     - port: 30000:32767 # nodePorts
       proto: tcp
-  when: ansible_os_family == "Debian"
+  when: active_firewall == "ufw"
 
 - name: Allow trusted subnets via ufw on Debian systems
   community.general.ufw:
@@ -73,4 +85,4 @@
   loop:
     - 10.42.0.0/16 # k3s pods
     - 10.43.0.0/16 # k3s services
-  when: ansible_os_family == "Debian"
+  when: active_firewall == "ufw"

--- a/ansible/roles/k8s_firewalld/tasks/main.yml
+++ b/ansible/roles/k8s_firewalld/tasks/main.yml
@@ -23,7 +23,7 @@
     - "4789/udp" # Calico VXLAN Overlay
     - "30000-32767/tcp" # nodeports
     - "30000-32767/udp" # nodeports
-  notify: reload firewalld
+  notify: Reload firewalld
   when: ansible_os_family == "RedHat"
 
 - name: Remove trusted subnets from public zone
@@ -31,7 +31,7 @@
   loop:
     - 10.42.0.0/16 # k3s pods
     - 10.43.0.0/16 # k3s services
-  notify: reload firewalld
+  notify: Reload firewalld
   when: ansible_os_family == "RedHat"
 
 - name: Open trusted subnets
@@ -39,7 +39,7 @@
   loop:
     - 10.42.0.0/16 # k3s pods
     - 10.43.0.0/16 # k3s services
-  notify: reload firewalld
+  notify: Reload firewalld
   when: ansible_os_family == "RedHat"
 
 - name: Open ports via ufw on Debian systems

--- a/ansible/roles/k8s_haproxy/tasks/main.yml
+++ b/ansible/roles/k8s_haproxy/tasks/main.yml
@@ -19,7 +19,7 @@
     zone: public
     state: enabled
     port: "{{ item }}"
-  notify: reload firewalld
+  notify: Reload firewalld
   with_items:
     - "{{ k8s_api_port }}/tcp" # k0s api port
     - "9443/tcp" # join api port
@@ -45,4 +45,4 @@
     prepend_newline: true
     marker: "# {mark} K8S HAProxy Settings"
     block: "{{ lookup('template', '00_k8s.cfg.j2') }}"
-  notify: restart haproxy
+  notify: Restart haproxy

--- a/ansible/roles/k8s_haproxy/tasks/main.yml
+++ b/ansible/roles/k8s_haproxy/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Set firewall fact
+  ansible.builtin.set_fact:
+    active_firewall: >-
+      {% if ansible_facts.services['firewalld.service'] is defined
+          and ansible_facts.services['firewalld.service'].state == 'running' %}firewalld
+      {%- elif ansible_facts.services['ufw.service'] is defined
+            and ansible_facts.services['ufw.service'].state == 'running' %}ufw
+      {%- else %}none{% endif %}
+
 - name: Open the API Port
   become: true
   community.general.ufw:
@@ -9,7 +21,7 @@
     - "{{ k8s_api_port }}" # k0s api
     - "9443" # join api
     - "8132" # konnectivity
-  when: ansible_os_family == 'Debian'
+  when: active_firewall == "ufw"
 
 - name: Open the API port
   become: true
@@ -24,18 +36,7 @@
     - "{{ k8s_api_port }}/tcp" # k0s api port
     - "9443/tcp" # join api port
     - "8132/tcp" # konnectivity server
-  when: ansible_os_family == 'RedHat'
-
-# - name: configure k8s haproxy settings
-#   become: true
-#   ansible.builtin.template:
-#     src: 00_k8s.cfg.j2
-#     dest: /etc/haproxy/conf.d/00_k8s.cfg.j2
-#     owner: root
-#     group: root
-#     mode: 0644
-#   notify:
-#     - restart haproxy
+  when: active_firewall == "firewalld"
 
 - name: Configure k8s haproxy settings
   become: true

--- a/ansible/roles/k8s_nodes/tasks/main.yml
+++ b/ansible/roles/k8s_nodes/tasks/main.yml
@@ -61,7 +61,7 @@
         regexp: "^(\\s*)([^#\\n]+\\s+)(\\w+\\s+)swap(\\s+.*)$"
         replace: "#\\1\\2\\3swap\\4"
         backup: true
-      notify: reboot host
+      notify: Reboot host
 
     - name: Set ip_forwarding to 1 via sysctl
       ansible.posix.sysctl:
@@ -70,7 +70,7 @@
         sysctl_set: true
         state: present
         reload: true
-      notify: reboot host
+      notify: Reboot host
 
     - name: Red hat family configuration
       when: ansible_os_family == "RedHat"
@@ -143,13 +143,13 @@
           become: true
           ansible.builtin.command: setenforce 0
           ignore_errors: true
-          notify: reboot host
+          notify: Reboot host
 
         - name: Set permissive mode for SELinux
           become: true
           ansible.builtin.shell: sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
           ignore_errors: true
-          notify: reboot host
+          notify: Reboot host
 
     # - name: add the kubernetes yum repository
     #   ansible.builtin.yum_repository:

--- a/ansible/roles/nvidia_container_toolkit/tasks/main.yml
+++ b/ansible/roles/nvidia_container_toolkit/tasks/main.yml
@@ -13,7 +13,7 @@
       - libnvidia-container-tools
       - libnvidia-container1
     state: present
-  notify: reboot host
+  notify: Reboot host
 
 - name: Configure the nvidia container toolkit runtime
   ansible.builtin.command:
@@ -27,4 +27,4 @@
       - --runtime
       - "{{ nvidia_container_toolkit_runtime }}"
     creates: "{{ nvidia_container_toolkit_runtime_config_path }}"
-  notify: reboot host
+  notify: Reboot host

--- a/ansible/roles/nvidia_drivers/tasks/main.yml
+++ b/ansible/roles/nvidia_drivers/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.package:
     name: "*"
     state: latest
-  notify: reboot host
+  notify: Reboot host
 
 - name: Enable additional DNF repositories
   community.general.dnf_config_manager:
@@ -67,7 +67,7 @@
       - pkgconfig
       - dkms
     state: present
-  notify: reboot host
+  notify: Reboot host
 
 - name: Disable Nouveau drivers
   community.general.kernel_blacklist:
@@ -98,7 +98,7 @@
   ansible.builtin.dnf:
     name: "@nvidia-driver:latest-dkms"
     state: present
-  notify: reboot host
+  notify: Reboot host
 
 - name: Install CUDA development dependencies
   ansible.builtin.package:
@@ -110,4 +110,4 @@
       - mesa-libGLU-devel
       - freeimage-devel
     state: present
-  notify: reboot host
+  notify: Reboot host

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -25,7 +25,7 @@
     state: enabled
     port: "5432/tcp"
   when: active_firewall == "firewalld"
-  notify: reload firewalld
+  notify: Reload firewalld
 
 - name: Install on Debian family systems
   when: ansible_os_family == "Debian"
@@ -65,4 +65,4 @@
         cmd: /usr/bin/postgresql-setup --initdb
         creates: "/var/lib/pgsql/data"
       notify:
-        - restart postgres
+        - Restart postgres

--- a/ansible/roles/postgresql_access/tasks/main.yml
+++ b/ansible/roles/postgresql_access/tasks/main.yml
@@ -12,7 +12,7 @@
     address: "{{ item }}"
     method: scram-sha-256
   loop: "{{ dbms_allowed_local_addresses }}"
-  notify: restart postgres
+  notify: Restart postgres
 
 - name: Add remote access to pg_hba.conf
   community.postgresql.postgresql_pg_hba:
@@ -23,7 +23,7 @@
     address: "{{ item }}"
     method: scram-sha-256
   loop: "{{ dbms_allowed_remote_addresses }}"
-  notify: restart postgres
+  notify: Restart postgres
 
 - name: Start postgresql if not already running
   ansible.builtin.service:
@@ -36,7 +36,7 @@
   community.postgresql.postgresql_set:
     name: listen_addresses
     value: "*"
-  notify: restart postgres
+  notify: Restart postgres
 
 - name: Set password for postgres user
   become: true

--- a/ansible/roles/ui_haproxy/tasks/main.yml
+++ b/ansible/roles/ui_haproxy/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Set firewall fact
+  ansible.builtin.set_fact:
+    active_firewall: >-
+      {% if ansible_facts.services['firewalld.service'] is defined
+          and ansible_facts.services['firewalld.service'].state == 'running' %}firewalld
+      {%- elif ansible_facts.services['ufw.service'] is defined
+            and ansible_facts.services['ufw.service'].state == 'running' %}ufw
+      {%- else %}none{% endif %}
+
 - name: Open the HTTP/S Port
   become: true
   community.general.ufw:
@@ -10,7 +22,7 @@
       proto: tcp
     - port: 443
       proto: tcp
-  when: ansible_os_family == 'Debian'
+  when: active_firewall == "ufw"
 
 - name: Open the HTTP/S port
   become: true
@@ -24,7 +36,7 @@
   with_items:
     - "80/tcp" # join api port
     - "443/tcp" # konnectivity server
-  when: ansible_os_family == 'RedHat'
+  when: active_firewall == "firewalld"
 
 - name: Set repo_dir fact
   ansible.builtin.set_fact:
@@ -33,27 +45,6 @@
 - name: Set secrets_dir fact
   ansible.builtin.set_fact:
     secrets_dir: "{{ [repo_dir, secrets_loader_base_dir] | path_join }}"
-
-- name: Copy ssl files
-  become: true
-  ansible.builtin.copy:
-    dest: /etc/ssl/
-    src: "{{ secrets_dir }}/{{ item }}"
-    mode: "0600"
-    owner: root
-    group: root
-  with_items: "{{ secrets_loader_ssl_filepaths }}"
-
-# - name: configure ui haproxy settings
-#   become: true
-#   ansible.builtin.template:
-#     src: 01_de.cfg.j2
-#     dest: /etc/haproxy/conf.d/01_de.cfg.j2
-#     owner: root
-#     group: root
-#     mode: 0644
-#   notify:
-#     - restart haproxy
 
 - name: Configure ui haproxy settings
   become: true

--- a/ansible/roles/ui_haproxy/tasks/main.yml
+++ b/ansible/roles/ui_haproxy/tasks/main.yml
@@ -32,7 +32,7 @@
     zone: public
     state: enabled
     port: "{{ item }}"
-  notify: reload firewalld
+  notify: Reload firewalld
   with_items:
     - "80/tcp" # join api port
     - "443/tcp" # konnectivity server
@@ -54,4 +54,4 @@
     prepend_newline: true
     marker: "# {mark} DE UI HAProxy Settings"
     block: "{{ lookup('template', '01_de.cfg.j2') }}"
-  notify: restart haproxy
+  notify: Restart haproxy

--- a/ansible/roles/ui_haproxy/templates/01_de.cfg.j2
+++ b/ansible/roles/ui_haproxy/templates/01_de.cfg.j2
@@ -2,67 +2,15 @@ frontend localhost
     bind *:80
     redirect scheme https
 
-frontend http2-ssl
-    bind *:443 ssl crt /etc/ssl/cyverse.combined alpn h2,http/1.1 crt /etc/ssl/cyverse.combined
+frontend https
+    bind *:443
+    mode tcp
+    option tcplog
+    default_backend: gateway
 
-{% if harbor_enabled %}
-    acl harbor hdr(host) -i {{ harbor_fqdn }}
-{% endif %}
-{% if gocd_enabled %}
-    acl gocd hdr(host) -i {{ gocd_external_domain }}
-{% endif %}
-{% if portal %}
-    acl portal hdr(host) -i {{ portal_hostname}}
-{% endif %}
-    acl de hdr(host) -i {{ de_hostname }}
-
-    # HSTS (63072000 seconds)
-    http-response set-header Strict-Transport-Security max-age=63072000
-{% if gocd_enabled %}
-    use_backend gocd if gocd
-{% endif %}
-{% if harbor_enabled %}
-    use_backend harbor if harbor
-{% endif %}
-{% if portal %}
-    use_backend discoenv if portal
-{% endif %}
-    use_backend discoenv if de
-    default_backend discoenv
-
-{% if gocd_enabled %}
-backend gocd
-    option log-health-checks
-    option forwardfor
-
-    http-request add-header X-Forwarded-Proto https
-
+backend gateway
     balance roundrobin
-{% for svr in groups['gocd_server'] %}
-    server {{ svr }} {{ svr }}:8153 verify none check inter 5000
-{% endfor %}
-{% endif %}
-
-{% if harbor_enabled %}
-backend harbor
-    option log-health-checks
-    option forwardfor
-
-    http-request add-header X-Forwarded-Proto https
-
-    balance roundrobin
+    mode tcp
 {% for svr in groups['k8s_de_workers'] %}
-    server {{ svr }} {{ svr }}:{{ harbor_nodeport }} check inter 5000
-{% endfor %}
-{% endif %}
-
-backend discoenv
-    option log-health-checks
-    option forwardfor
-
-    http-request add-header X-Forwarded-Proto https
-
-    balance roundrobin
-{% for svr in groups['k8s_de_workers'] %}
-    server {{ svr }} {{ svr }}:31344 ssl verify none check inter 5000
+    server {{ svr }} {{ svr }}:{{ traefik_https_port }} check inter 5000
 {% endfor %}

--- a/ansible/roles/ui_haproxy/templates/01_de.cfg.j2
+++ b/ansible/roles/ui_haproxy/templates/01_de.cfg.j2
@@ -6,7 +6,7 @@ frontend https
     bind *:443
     mode tcp
     option tcplog
-    default_backend: gateway
+    default_backend gateway
 
 backend gateway
     balance roundrobin


### PR DESCRIPTION
Part 3 of 6 splitting the `CORE-2156` cleanup branch.

Commits #12–17: HAProxy in TCP mode for DE services, group_vars docs for the load-balancer phase, notify/handler realignment, k8s_haproxy and k8s_firewalld now detect the active firewall (firewalld vs ufw) directly, and a UI haproxy config-template fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)