### PR TITLE
CORE-2156: k0s cluster bootstrap (4/6)

### DIFF
--- a/ansible/example/inventory/group_vars/all.yaml
+++ b/ansible/example/inventory/group_vars/all.yaml
@@ -461,3 +461,44 @@
 # the k0s containerd config-fragment directory.
 # Default: /etc/k0s/containerd.d/nvidia.toml
 # nvidia_container_toolkit_runtime_config_path: /etc/k0s/containerd.d/nvidia.toml
+
+
+# =====================================================================
+# Phase 5: Create the k0s Cluster
+# =====================================================================
+# Variables consulted by `kubernetes.yml --tags create-cluster` (runs
+# `k0sctl apply` against the controllers and workers and writes out the
+# resulting kubeconfig).
+#
+# Run this phase after the HAProxy load balancer (Phase 3) is in place
+# and the nodes have been prepared (Phase 4) — k0sctl talks to the API
+# through the load balancer and expects the node OS to already be set
+# up.
+#
+# This phase runs locally (`connection: local`) on the first host in
+# `k8s_controllers`. It shells out to `k0sctl`, so the `k0sctl` binary
+# must be installed on the machine running ansible-playbook (not on the
+# controller).
+#
+# The `k8s_cluster` role does not consult any group_vars. Its behavior
+# is governed entirely by two operational inputs:
+#
+#   1. `k0sctl.yaml` — a static configuration file the role expects to
+#      find next to the inventory directory (e.g.
+#      `example/k0sctl.yaml` alongside `example/inventory/`). It lists
+#      the controller and worker hosts, the k0s version to install, and
+#      any cluster-wide k0s configuration. Keep the k0s version in sync
+#      with the `k8s_version` configured in Phase 4.
+#
+#   2. `KUBECONFIG` — environment variable read from the shell running
+#      ansible-playbook. It is the *destination* path where this phase
+#      writes the newly minted kubeconfig (mode 0600); the file does
+#      not need to exist yet, but the variable must be set or the
+#      `k0sctl kubeconfig` redirect and the follow-up file task will
+#      both fail. Later phases (`de-reqs`, `configure-services`,
+#      deploys) read this same path to authenticate against the
+#      cluster.
+#
+# There are no variables to uncomment in this section — it exists only
+# to document the prerequisites above.
+# =====================================================================

--- a/ansible/example/k0sctl.yaml
+++ b/ansible/example/k0sctl.yaml
@@ -1,0 +1,54 @@
+# This is an example configuration file for a two-node cluster running both the
+# data store and the Discovery Environment.
+#
+# cworker.example.org serves as both a controller and a worker. All DE services
+# will run on this node in addition to the data store.
+#
+# worker.example.org serves as a Kubernetes worker node reserved for DE
+# analyses. The DE services will not run on this node.
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: k0s-cluster
+spec:
+  hosts:
+    - ssh:
+        address: cworker.example.org
+        user: ${K0S_SSH_USER}
+        port: 1657
+        keyPath: ${K0S_SSH_KEY_PATH}
+      role: controller+worker
+      installFlags:
+        - --profile=irods-node
+    - ssh:
+        address: worker.example.org
+        user: ${K0S_SSH_USER}
+        port: 1657
+        keyPath: ${K0S_SSH_KEY_PATH}
+      role: worker
+      installFlags:
+        - "--labels analysis=true,vice=true"
+        - "--taints analysis=only:NoSchedule"
+  k0s:
+    version: v1.35.4+k0s.0
+    config:
+      spec:
+        api:
+          externalAddress: swcacti1.cyverse.org
+        network:
+          podCIDR: 10.42.0.0/16
+          serviceCIDR: 10.42.0.0/16
+          provider: calico
+          calico:
+            envVars:
+              IP_AUTODETECTION_METHOD: "interface=en.*"
+        workerProfiles:
+          - name: irods-node
+            values:
+              systemReserved:
+                cpu: "1"
+                memory: "8Gi"
+                ephemeral-storage: "800Gi"
+              kubeReserved:
+                cpu: "1"
+                memory: "2Gi"

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -245,6 +245,7 @@
   become: true
   hosts: de_haproxy
   roles:
+    - role: haproxy
     - role: ui_haproxy
   tags:
     - haproxy

--- a/ansible/roles/k8s_cluster/tasks/main.yml
+++ b/ansible/roles/k8s_cluster/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Apply k0sctl cluster configuration
+  delegate_to: localhost
   environment:
     KUBECONFIG: "{{ lookup('env', 'KUBECONFIG') }}"
     SSH_KNOWN_HOSTS: /dev/null # Needed for some reason due to how we configure our connection to the hosts.

--- a/ansible/roles/k8s_cluster/tasks/main.yml
+++ b/ansible/roles/k8s_cluster/tasks/main.yml
@@ -15,7 +15,11 @@
 
     - name: Apply k0sctl configuration
       ansible.builtin.command:
-        cmd: "k0sctl apply --config {{ yaml_path }}"
+        argv:
+          - "k0sctl"
+          - "apply"
+          - "--config"
+          - "{{ yaml_path }}"
 
     - name: Write out kubeconfig
       ansible.builtin.shell:

--- a/ansible/roles/k8s_firewalld/tasks/main.yml
+++ b/ansible/roles/k8s_firewalld/tasks/main.yml
@@ -38,6 +38,27 @@
   notify: Reload firewalld
   when: active_firewall == "firewalld"
 
+- name: Open the ports
+  ansible.posix.firewalld:
+    permanent: true
+    immediate: true
+    state: enabled
+    port: "{{ item }}"
+    zone: internal
+  loop:
+    - "6443/tcp" # k8s api
+    - "2380/tcp" # etcd
+    - "10250/tcp" # kubelet
+    - "9443/tcp" # k0s join api
+    - "179/tcp" # bgp, worker-worker
+    - "8132/tcp" # konnectivity
+    - "112/tcp" # keepalived, possibly unnecessary
+    - "4789/udp" # Calico VXLAN Overlay
+    - "30000-32767/tcp" # nodeports
+    - "30000-32767/udp" # nodeports
+  notify: Reload firewalld
+  when: active_firewall == "firewalld"
+
 - name: Remove trusted subnets from public zone
   ansible.builtin.command: "firewall-cmd --zone=public --remove-source={{ item }} --permanent"
   loop:


### PR DESCRIPTION
Part 4 of 6 splitting the `CORE-2156` cleanup branch.

Commits #18–22: docs and example for the k0sctl cluster-creation step, a fix to the k0sctl task, running the cluster-creation commands on the local host, ensuring haproxy is installed when no haproxy host is defined, and opening the internal-zone ports Kubernetes needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)