### PR TITLE
CORE-2156: Longhorn replicated storage (6/6)

### DIFF
--- a/ansible/example/inventory/group_vars/all.yaml
+++ b/ansible/example/inventory/group_vars/all.yaml
@@ -502,3 +502,42 @@
 # There are no variables to uncomment in this section — it exists only
 # to document the prerequisites above.
 # =====================================================================
+
+
+# =====================================================================
+# In-cluster storage: Longhorn
+# =====================================================================
+# Installed by the `longhorn` role during the create-cluster phase (it
+# runs before `openldap-docker`, which depends on a persistent volume).
+# Longhorn provides replicated local block storage via a StorageClass
+# named `longhorn`. The class is NOT made the cluster default, so PVCs
+# must set `storageClassName: longhorn` explicitly.
+
+# Whether to install Longhorn.
+# Default: false
+# longhorn_enabled: true
+
+# Namespace Longhorn is installed into.
+# Default: longhorn-system
+# longhorn_namespace: longhorn-system
+
+# Longhorn Helm chart version.
+# Default: 1.12.0
+# longhorn_version: 1.12.0
+
+# Number of replicas per volume. The default adapts to the cluster size,
+# using the worker count capped at 3, so clusters with 1 or 2 nodes don't
+# end up with permanently degraded volumes. Set an explicit integer to
+# override.
+# Default: "{{ [groups['k8s_workers'] | length, 3] | min }}"
+# longhorn_replica_count: 3
+
+# On-node directory where Longhorn stores replica data.
+# Default: /var/lib/longhorn
+# longhorn_data_path: /var/lib/longhorn
+
+# Reclaim policy for the longhorn StorageClass. Retain keeps the data
+# when a PVC is deleted; set to Delete to reclaim it automatically.
+# Default: Retain
+# longhorn_reclaim_policy: Retain
+# =====================================================================

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -88,6 +88,9 @@
     - role: k8s_de_reqs
       tags: de-reqs
 
+    - role: longhorn
+      tags: longhorn
+
     - role: openldap-docker
       tags: openldap-docker
 

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -332,6 +332,20 @@ irods_csi_driver_cache_timeout_settings: '[{"path":"/","timeout":"-1ns","inherit
 irods_csi_driver_kubelet_dir: "/var/lib/k0s/kubelet"
 irods_csi_driver_pool_server_endpoint: rodsfs.example.org:12020
 
+# Longhorn replicated block storage
+longhorn_enabled: false
+longhorn_namespace: longhorn-system
+longhorn_version: "1.12.0"
+longhorn_repo: https://charts.longhorn.io
+# Replicas adapt to cluster size, capped at 3 (a node count of 1 or 2 yields
+# 1 or 2 replicas so volumes don't stay degraded). Override per-environment.
+longhorn_replica_count: "{{ [groups['k8s_workers'] | length, 3] | min }}"
+longhorn_data_path: /var/lib/longhorn
+# Retain (vs the chart default Delete) so removing a PVC doesn't immediately
+# destroy the underlying data.
+longhorn_reclaim_policy: Retain
+longhorn_storage_class: longhorn
+
 # NVIDIA Container Toolkit Vars
 nvidia_container_toolkit_runtime: containerd
 nvidia_container_toolkit_runtime_config_path: /etc/k0s/containerd.d/nvidia.toml

--- a/ansible/roles/deploy-service/tasks/main.yml
+++ b/ansible/roles/deploy-service/tasks/main.yml
@@ -23,13 +23,14 @@
       run_once: true
       ansible.builtin.command:
         chdir: "{{ de_releases_dir }}/services/{{ project_name }}"
-        argv:
-          - skaffold
-          - deploy
-          - "--namespace"
-          - "{{ deploy_ns | default(ns) }}"
-          - "--build-artifacts"
-          - "../../builds/{{ project_name }}.json"
-          - "--force"
-          - "--kubeconfig"
-          - "{{ lookup('env', 'KUBECONFIG') }}"
+        # deploy_profile is optional: when set, it activates a skaffold profile
+        # (e.g. a kustomize overlay) without affecting callers that don't set it.
+        argv: >-
+          {{
+            ['skaffold', 'deploy',
+             '--namespace', deploy_ns | default(ns),
+             '--build-artifacts', '../../builds/' + project_name + '.json',
+             '--force',
+             '--kubeconfig', lookup('env', 'KUBECONFIG')]
+            + (['--profile', deploy_profile] if deploy_profile is defined else [])
+          }}

--- a/ansible/roles/k8s_nodes/tasks/main.yml
+++ b/ansible/roles/k8s_nodes/tasks/main.yml
@@ -181,6 +181,12 @@
             state: present
           when: ansible_os_family == "Debian"
 
+        - name: Enable iscsid on debian systems
+          ansible.builtin.service:
+            name: iscsid
+            state: started
+            enabled: true
+
         - name: Create the /etc/apt/keyrings directory
           ansible.builtin.file:
             path: /etc/apt/keyrings

--- a/ansible/roles/longhorn/meta/main.yml
+++ b/ansible/roles/longhorn/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/ansible/roles/longhorn/tasks/main.yml
+++ b/ansible/roles/longhorn/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Install Longhorn replicated block storage
+  delegate_to: localhost
+  run_once: true
+  when: longhorn_enabled | bool
+  environment:
+    KUBECONFIG: "{{ lookup('env', 'KUBECONFIG') }}"
+  block:
+    # The chart auto-creates a StorageClass named "longhorn" (matching
+    # harbor_storage_class). It is not made the cluster default, so PVCs must
+    # reference it by name. Replica count is configured via the persistence and
+    # defaultSettings values so it can adapt to clusters with fewer than 3 nodes.
+    - name: Install the longhorn helm chart
+      kubernetes.core.helm:
+        create_namespace: true
+        release_namespace: "{{ longhorn_namespace }}"
+        release_name: longhorn
+        chart_repo_url: "{{ longhorn_repo }}"
+        chart_ref: longhorn
+        chart_version: "{{ longhorn_version }}"
+        wait: true
+        values:
+          persistence:
+            defaultClass: false
+            defaultClassReplicaCount: "{{ longhorn_replica_count | int }}"
+            reclaimPolicy: "{{ longhorn_reclaim_policy }}"
+          defaultSettings:
+            defaultReplicaCount: "{{ longhorn_replica_count | int }}"
+            defaultDataPath: "{{ longhorn_data_path }}"


### PR DESCRIPTION
Adds Longhorn replicated block storage to back the in-cluster OpenLDAP deployment.

6/6, the last in the CORE-2156 cleanup split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)