### PR TITLE
Add skills/ collection documenting DE build, deploy, and release workflows

### DIFF
--- a/skills/adding-a-de-service-role/SKILL.md
+++ b/skills/adding-a-de-service-role/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: adding-a-de-service-role
+description: Use when adding a brand-new CyVerse DE service to the deployments repo — scaffolding roles/services/<service>/ and wiring it into cloning, building, and deploying so it behaves like the existing services.
+---
+
+# Adding a DE Service Role
+
+## Overview
+
+Each DE service is a self-contained role under `roles/services/<service>/`. The
+generic `build-service` and `deploy-service` roles do the real work, parameterized
+by `project_name`, so a service role is mostly boilerplate plus its own
+`skaffold.yaml`, k8s manifest, and config template. Adding a service = **create
+the role** + **wire it into four existing files**. Get every naming invariant
+below to agree, or the config secret won't mount or the deploy will look for the
+wrong image.
+
+## The Naming Invariants (make these all agree)
+
+For a service named `<svc>`:
+
+- Role directory = `<svc>` = `project_name` = the build/deploy **tag**.
+- Image = `harbor.cyverse.org/de/<svc>` (in both `skaffold.yaml` and the k8s
+  manifest's `image:`). `build-service` rewrites `harbor.cyverse.org` →
+  `image_registry` at build time.
+- Config secret = `<svc>-configs`. Its **data key**, the **filename mounted**
+  into the container (volume `items[].path` + the file under `mountPath`), and
+  the config the service reads must all be the same filename.
+- `skaffold.yaml` `manifests.rawYaml` points at `k8s/<svc>.yml`.
+
+## Files to Create (the role)
+
+```
+roles/services/<svc>/
+  meta/main.yml
+  tasks/build.yml
+  tasks/main.yml
+  templates/<svc>.<ext>.j2     # config template — OMIT if the service needs no config
+  files/skaffold.yaml
+  files/k8s/<svc>.yml
+  files/<svc>.json             # build descriptor
+```
+
+**`meta/main.yml`**
+```yaml
+---
+dependencies:
+  - role: common
+```
+
+**`tasks/build.yml`**
+```yaml
+---
+- name: build the <svc> image
+  ansible.builtin.include_role:
+    name: build-service
+    tasks_from: main
+  vars:
+    project_name: <svc>
+  tags:
+    - build
+```
+
+**`tasks/main.yml`** (creates the config secret, then deploys). For a service
+with **no config**, drop the secret task and keep only the `include_role`
+(see `maintenance-page` for that shape).
+```yaml
+---
+- delegate_to: localhost
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+  block:
+    - name: create the <svc>-configs secret
+      run_once: true
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: <svc>-configs
+            namespace: "{{ ns }}"
+          data:
+            <svc>.yml: "{{ lookup('template', '<svc>.yml.j2') | b64encode }}"
+      when: load_configs is undefined or (load_configs | bool)
+
+    - ansible.builtin.include_role:
+        name: deploy-service
+        tasks_from: main
+      vars:
+        project_name: <svc>
+```
+
+**`files/skaffold.yaml`**
+```yaml
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: <svc>
+build:
+  artifacts:
+    - image: harbor.cyverse.org/de/<svc>
+      custom:
+        buildCommand: ./buildx-build.sh
+        dependencies:
+          paths: ["**"]
+  platforms:
+    - "linux/amd64"
+  tagPolicy:
+    gitCommit: {}
+  local: {}
+manifests:
+  rawYaml:
+    - k8s/<svc>.yml
+deploy:
+  kubectl: {}
+```
+
+**`files/<svc>.json`** (seed descriptor; the first push build overwrites it with
+the real `<image>:<ref>@sha256:<digest>`):
+```json
+{"builds":[{"imageName":"harbor.cyverse.org/de/<svc>","tag":"harbor.cyverse.org/de/<svc>:main"}]}
+```
+
+**`files/k8s/<svc>.yml` and `templates/<svc>.<ext>.j2` are service-specific** —
+don't hand-write from scratch. **Copy the closest existing service** (a Go
+service like `app-exposer` or `data-usage-api`; a Clojure service like `terrain`)
+and rename. The manifest is a `Deployment` + `Service`; keep the config-secret
+volume/mount wiring consistent with the invariants above, and trim RBAC/NATS/DB
+bits the service doesn't use.
+
+## Files to Edit (the wiring — 4 points)
+
+| File | Add | Purpose |
+| --- | --- | --- |
+| `roles/common/defaults/main.yml` | `- <svc>` in the `source_repos` list | so `clone_sources.yml` clones the source repo. Add `source_repo_urls` only if the repo isn't under `git@github.com:cyverse-de`. |
+| `build_it.yml` | an `include_role` block with `tasks_from: build`, `apply.tags: <svc>`, and `tags: <svc>` | so `build_it.yml --tags <svc>` builds it |
+| `deploy_it.yml` | `- role: services/<svc>` with `tags: <svc>` | so `deploy_it.yml --tags <svc>` deploys it |
+| `kubernetes.yml` | `- role: services/<svc>` in the **Deploy all services** `roles:` list | so a full run deploys it |
+
+`build_it.yml` block to add:
+```yaml
+    - ansible.builtin.include_role:
+        name: services/<svc>
+        tasks_from: build
+        apply:
+          tags: <svc>
+      tags: <svc>
+```
+
+**No edit needed:** `build_release.yml` auto-discovers roles under
+`roles/services/`; `kubernetes.yml`'s single-service play resolves
+`services/{{ project }}` dynamically (`-e project=<svc>`); the `build-service` /
+`deploy-service` roles are generic.
+
+## Order of Operations
+
+1. Create the role files and make the four wiring edits.
+2. Clone the source repo — `cloning-de-source-repos` (its `source_repos` entry
+   now exists).
+3. Build and push — `building-de-service-images` (`build_it.yml --tags <svc>`).
+   This rewrites `files/<svc>.json` with the real digest.
+4. Review and **commit** the updated descriptor (builds never commit it).
+5. Deploy — `deploying-de-services` (`deploy_it.yml --tags <svc>`).
+
+## Common Mistakes
+
+- **Forgetting `source_repos`.** The most-missed point — without it
+  `clone_sources.yml` won't fetch the source and builds fail with "no repo".
+- **Wiring only some playbooks.** All four edits are needed; a service in
+  `build_it.yml` but not `deploy_it.yml`/`kubernetes.yml` builds but never deploys
+  (and vice versa).
+- **Mismatched config filename.** The secret data key, the volume `items[].path`,
+  the `mountPath` filename, and the template output must be the same name, or the
+  service won't find its config.
+- **Deploying before building.** The seed descriptor has no real digest; run a
+  push build first so `files/<svc>.json` points at a pushed image.
+- **Hand-writing the k8s manifest.** Copy a similar service and adjust — it's
+  easy to miss labels/anti-affinity/probes conventions.
+
+## Beyond the Basic Service
+
+A service that needs a **database**, a group_vars **enable flag**, extra
+**RBAC/ServiceAccounts**, or that other services must **reach by URL**
+(`baseurls_<svc>`) needs more than this scaffold — model those on the analogous
+existing service (e.g. `qms` for a DB-backed service) and the `postgresql_init`
+role / `service_configurations` role as applicable.

--- a/skills/building-de-service-images/SKILL.md
+++ b/skills/building-de-service-images/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: building-de-service-images
+description: Use when building, rebuilding, or verifying a CyVerse DE service container image from source in the deployments repo — e.g. "build the formation image", building at a specific git tag, or checking that a service still builds without pushing.
+---
+
+# Building DE Service Images
+
+## Overview
+
+In the CyVerse DE `deployments` repo, each service has a role under
+`ansible/roles/services/<service>/`. Images are built from the service's **own
+source repo** (a sibling checkout), but the `skaffold.yaml` and `k8s/` manifests
+always come from the service role here — the deployments repo is the source of
+truth. Builds are driven by the `build_it.yml` playbook and gated behind tags.
+
+**Run all commands from the `ansible/` directory.**
+
+## Choosing the Inventory
+
+Every command needs `-i <inventory>` pointing at the private inventory for the
+**target environment** (QA, prod, local, …). The inventory determines which
+cluster and registry you act on, so never assume one:
+
+- If the request names an environment/inventory, or one was already agreed
+  earlier in this session, use that.
+- Otherwise **ask the user which environment/inventory to use before running.**
+  Do not default to a `$QA_INVENTORY` (or any other) env var — different
+  environments use different inventory paths and different variables.
+
+The examples below write `-i <inventory>` for this reason; substitute the
+inventory you were given or agreed on.
+
+## When to Use
+
+- Building one or more DE service images from source
+- Verifying a service still builds (no push) after a change
+- Building a service at a specific git tag/ref
+- NOT for deploying (that's `deploy_it.yml`) or rebuilding a whole release
+  from recorded refs (that's `build_release.yml`, which reads each ref from the
+  service's descriptor instead of taking `git_ref`)
+
+## Quick Reference
+
+| Goal | Command |
+| --- | --- |
+| Build one service | `ansible-playbook -i <inventory> build_it.yml --tags formation` |
+| Build several at once | `ansible-playbook -i <inventory> build_it.yml --tags terrain,apps` |
+| Build at a specific ref | `... build_it.yml --tags formation -e git_ref=v2025.12.02` |
+| Verify only (no push) | `... build_it.yml --tags formation -e push_images=false` |
+| Bypass skaffold's cache | `... build_it.yml --tags formation -e force_rebuild=true` |
+
+Selection is by **tag**, and each service's tag equals its role name. Builds
+**never run by default** — with no `--tags` nothing builds.
+
+## Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `git_ref` | `main` | Git ref to build. Applies to the **whole invocation** — every tag in one run builds the same ref. |
+| `push_images` | `true` | Push the image and rewrite the descriptor. When `false`, build only. |
+| `force_rebuild` | `false` | Pass `--cache-artifacts=false` to bypass skaffold's artifact cache. |
+| `image_registry` | `harbor.cyverse.org` | Target registry, rewritten into the skaffold config. |
+| `source_repo_dir` | dir containing this repo | Where source repos are checked out (siblings by default). |
+| `source_repo` | `<source_repo_dir>/<source_service>` | Exact path to a service's source repo; override when the checkout name differs. |
+| `source_service` | the service's own name | Which repo to build from. Only override in play is `vice-operator`, which builds the `app-exposer` repo. |
+
+## What a Build Does
+
+For each selected service the `build-service` role, entirely on localhost:
+
+1. Asserts the source repo exists at `source_repo` (fails with guidance if not).
+2. `git fetch --tags --force`, then creates a temporary detached **git
+   worktree** at `git_ref` — your actual checkout is never modified.
+3. Overlays the role's `skaffold.yaml`, `k8s/`, and the shared `buildx-build.sh`
+   onto the worktree, and rewrites `harbor.cyverse.org` → `image_registry`.
+4. Ensures a container-driver `de-builder` buildx builder exists and selects it.
+5. Runs `skaffold build` through a custom builder (`buildx-build.sh`) that uses a
+   mode=max `<image>:cache` registry layer cache — so multi-stage dependency
+   downloads (e.g. Clojure Maven/Clojars) are reused instead of re-fetched. On a
+   push build it adds `--push --file-output <descriptor>`; otherwise `--load`.
+6. Rewrites `roles/services/<service>/files/<service>.json` with the new digest
+   — **only when pushing**.
+7. Removes the worktree and temp dir.
+
+## Prerequisites
+
+- **Docker** with BuildKit and **skaffold** on `PATH`.
+- The service source repos cloned under `source_repo_dir` (run
+  `ansible-playbook clone_sources.yml` if missing — no inventory needed).
+- For **push** builds, a `docker login` to the target registry already in place.
+  A verify-only (`push_images=false`) build needs no login and no registry.
+- An `-i <inventory>` is required even though every task runs locally — the
+  play targets `k8s_controllers[0]`. See **Choosing the Inventory** above; some
+  shells export the path as an env var (e.g. `$QA_INVENTORY`, see
+  `ansible/.env.sample`), but confirm the environment rather than assuming one.
+
+## Common Mistakes
+
+- **Expecting `push_images=false` to still push.** For these services it does
+  **not** push — the custom builder runs `docker buildx ... --load` when
+  `PUSH_IMAGE` isn't true. (An older BUILD_DEPLOY.md caveat about the default
+  skaffold local builder pushing anyway does not apply here; all 48 services use
+  the custom builder.) With `push_images=false` the descriptor is left untouched,
+  since an unpushed image has no registry digest to record.
+- **Building services at different refs in one run.** `git_ref` applies to the
+  whole invocation. For different refs, run them separately.
+- **Committing expectations.** The build **never commits** the changed
+  descriptor — review and commit `files/<service>.json` yourself.
+- **Looking for the descriptor in a de-releases checkout.** Builds always
+  **write** into the service role's own `files/` dir, regardless of any
+  `build_json_dir` override (that override only affects where *deploys* read).
+- **A release tag won't check out.** Usually a stale clone. Builds auto-fetch
+  tags, but re-run `clone_sources.yml` (or `git fetch --tags` in the source repo)
+  if a tag still won't resolve.

--- a/skills/cloning-de-source-repos/SKILL.md
+++ b/skills/cloning-de-source-repos/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cloning-de-source-repos
+description: Use when cloning the CyVerse DE service source repositories from the deployments repo — e.g. "clone the source repos", setting up the sibling checkouts that image builds need before running build_it.yml or build_release.yml.
+---
+
+# Cloning DE Source Repositories
+
+## Overview
+
+Building DE service images needs each service's **source repo** checked out
+locally. The `clone_sources.yml` playbook clones all of them (~48 repos) into
+`source_repo_dir`, skipping any already present. It runs entirely on localhost
+and needs **no inventory**.
+
+**Run the command from the `ansible/` directory.**
+
+## When to Use
+
+- Setting up the source checkouts before building images
+- Refreshing tags on already-cloned repos (a release builds from tags)
+- NOT for building or deploying — this only clones/updates source repos
+
+## Choosing Where to Store the Repos
+
+The repos land in `source_repo_dir`. Its default is the directory **containing**
+the deployments repo (so the checkouts are siblings), which is what builds
+expect — but cloning ~48 repos is a real filesystem side effect, so pick the
+location deliberately:
+
+- If the request names a location, or one was agreed earlier in this session,
+  use it (`-e source_repo_dir=<path>`).
+- Otherwise **ask the user where to store the repos before running.** You may
+  offer the default (siblings of the deployments repo) as the suggested choice,
+  but do not silently default to it. When you ask, also ask **whether the choice
+  should apply to the rest of the session.**
+
+**Whatever location you choose, builds must use the same `source_repo_dir`.**
+`build_it.yml` / `build_release.yml` default it to the deployments repo's
+siblings; if you clone elsewhere, pass the same `-e source_repo_dir=<path>` to
+the build commands or they won't find the sources.
+
+## Quick Reference
+
+```bash
+# from the ansible/ directory; no inventory needed
+ansible-playbook clone_sources.yml -e source_repo_dir=<path>
+
+# clone over HTTPS instead of SSH
+ansible-playbook clone_sources.yml -e source_repo_dir=<path> \
+  -e cyverse_repo_base=https://github.com/cyverse-de
+```
+
+## What It Does
+
+1. Ensures `source_repo_dir` exists.
+2. Clones each repo in `source_repos` to `<source_repo_dir>/<repo>`, **skipping
+   any already cloned** (checks for `<repo>/.git`). Idempotent — it never
+   re-clones or modifies an existing checkout's working tree.
+3. For repos already present, runs `git fetch --tags --force origin` to refresh
+   tags/branches. Non-destructive: it updates refs only, not the tree.
+
+Clone URLs default to SSH (`git@github.com:cyverse-de/<repo>`). Per-repo
+overrides live in `source_repo_urls` (currently only `qms`, which is in the
+`cyverse` org).
+
+## Authentication
+
+- **SSH (default):** needs a configured GitHub SSH key. Some repos are private.
+- **HTTPS:** set `-e cyverse_repo_base=https://github.com/cyverse-de` and use a
+  credential helper (e.g. `gh auth setup-git`) for the private repos.
+
+## Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `source_repo_dir` | dir containing this repo (siblings) | Where the repos are cloned. |
+| `cyverse_repo_base` | `git@github.com:cyverse-de` | Default org base URL; set to the HTTPS base for HTTPS clones. |
+| `source_repos` | list in `common` | The repos to clone. |
+| `source_repo_urls` | `{qms: cyverse/qms}` | Per-repo URL overrides for repos not under `cyverse_repo_base`. |

--- a/skills/deploying-de-services/SKILL.md
+++ b/skills/deploying-de-services/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: deploying-de-services
+description: Use when deploying one or more CyVerse DE services to a cluster from the deployments repo — e.g. "deploy terrain", rolling out a freshly built image, or pushing several services to QA/prod/local with deploy_it.yml.
+---
+
+# Deploying DE Services
+
+## Overview
+
+In the CyVerse DE `deployments` repo, each service has a role under
+`ansible/roles/services/<service>/`. Deploying a service reads its **build
+descriptor** (`<service>.json`, which pins an exact image digest) and runs
+`skaffold deploy` against the target cluster using the canonical
+`skaffold.yaml` and `k8s/` manifests from the role. The `deploy_it.yml`
+playbook deploys services selected by tag.
+
+**Run all commands from the `ansible/` directory.**
+
+## When to Use
+
+- Deploying one or more DE services after building/pushing new images
+- Rolling out a service to QA, prod, or a local cluster
+- NOT for building images (that's `building-de-service-images` /
+  `build_it.yml`), and NOT for a full first-time environment stand-up (that's
+  `kubernetes.yml` with `configure-services` + `deploy-all-services`)
+
+## Choosing the Environment
+
+A deploy targets **two** things that must both resolve to the *same intended
+environment*: the **inventory** (`-i`) and the **kubeconfig** (which cluster).
+
+### Inventory
+
+- If the request names an environment/inventory, or one was agreed earlier in
+  this session, use it.
+- Otherwise **ask which inventory to use before running.**
+- **Deploying to production requires explicit approval** — confirm first, never
+  default to prod.
+
+### Kubeconfig (target cluster)
+
+**REQUIRED SUB-SKILL:** Resolve which cluster to deploy to with
+`resolving-the-kubeconfig` before running — the target comes from a
+session-agreed value, the inventory group_vars, or the `KUBECONFIG` env var, and
+`KUBECONFIG` alone does not guarantee the cluster you'll hit. Ask the user when
+the value is ambiguous; never write it to memory.
+
+## Quick Reference
+
+```bash
+# resolve the target cluster first (see Choosing the Environment); if the
+# session uses the env var, e.g.
+export KUBECONFIG=~/.kube/qa.conf
+```
+
+| Goal | Command |
+| --- | --- |
+| Deploy one service | `ansible-playbook -i <inventory> deploy_it.yml --tags terrain` |
+| Deploy several | `ansible-playbook -i <inventory> deploy_it.yml --tags terrain,sonora` |
+| Deploy image only (skip config re-render) | `... deploy_it.yml --tags terrain -e load_configs=false` |
+
+Selection is by **tag**, and each service's tag equals its role name.
+`--tags` order does **not** control sequencing — services run in the fixed
+order declared in `deploy_it.yml`.
+
+## Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `kubeconfig` | `$KUBECONFIG` env → `~/.kube/config`; overridable in inventory group_vars | Cluster to deploy to. Resolve it with `resolving-the-kubeconfig`. |
+| `ns` | `qa` (overridden by inventory) | Target namespace. |
+| `deploy_ns` | `ns` | Per-deploy namespace override, if set. |
+| `build_json_dir` | the service role's own `files/` dir | Directory deploys **read** descriptors from. Inventories may override it (QA points it at a sibling `de-releases/builds` checkout). |
+| `load_configs` | `true` | Whether to (re)render the per-service `<service>-configs` secret. Set `false` to deploy the image without touching config. |
+| `deploy_profile` | unset | Optional skaffold profile, if a role defines one. |
+
+## What a Deploy Does
+
+For each selected service, entirely on localhost with `KUBECONFIG` set:
+
+1. Renders the role's config template into the `<service>-configs` **secret** in
+   `ns` (skipped when `load_configs=false`).
+2. The `deploy-service` role reads `<build_json_dir>/<service>.json` and runs
+   `skaffold deploy --namespace <ns> --build-artifacts <descriptor> --force
+   --kubeconfig <kubeconfig>` from the role's `files/` dir. Because it passes the
+   descriptor as a build artifact, the cluster gets **exactly the pinned digest**
+   — not a floating tag — plus the canonical `k8s/` manifests from the role.
+
+## Prerequisites
+
+- **skaffold** on `PATH` and the `kubernetes.core` Ansible collection installed
+  (`ansible-galaxy install -r requirements.yml`).
+- `KUBECONFIG` pointing at the intended cluster (see **Choosing the
+  Environment**).
+- The environment must already be **configured**: `deploy_it.yml` does **not**
+  create the shared `configs` secret (or the `java-tool-options` configmap,
+  portal-conductor cert, etc.). Those come from the `configure-services` step
+  (`service_configurations` role) in `kubernetes.yml`. Deploying a service into a
+  namespace where that step hasn't run will start pods that can't mount `configs`.
+- The inventory must define the `k8s_controllers` group (the play targets
+  `k8s_controllers[0]` even though every task runs locally).
+
+## Common Mistakes
+
+- **Deploying a stale digest after a build.** Builds **write** the descriptor
+  into the service role's own `files/` dir, but deploys **read** from
+  `build_json_dir`, which an inventory may override to a separate
+  `de-releases/builds` checkout. If a freshly built image isn't picked up,
+  confirm the new descriptor was published to the location `build_json_dir`
+  resolves to (and that checkout is pulled up to date) — otherwise the deploy
+  ships the old digest.
+- **Clobbering hand-patched config.** With `load_configs` on (the default), the
+  deploy re-renders `<service>-configs` from the current inventory, reverting any
+  in-cluster edits. Use `-e load_configs=false` to deploy the image only.
+- **Deploying to the wrong cluster/namespace.** `KUBECONFIG` and `-i <inventory>`
+  are independent — if they point at different environments the deploy lands
+  somewhere unintended. Confirm both target the same environment before running.
+- **Assuming the tag order is the deploy order.** It isn't; order is fixed in
+  `deploy_it.yml`. This only matters if you expected sequencing between services.

--- a/skills/rebuilding-a-de-release/SKILL.md
+++ b/skills/rebuilding-a-de-release/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: rebuilding-a-de-release
+description: Use when rebuilding a CyVerse DE release's images from source in the deployments repo — rebuilding every service (or a subset) at the exact git refs their build descriptors are pinned to, with fresh digests, via build_release.yml.
+---
+
+# Rebuilding a DE Release
+
+## Overview
+
+A **release** is the set of git refs recorded across every service's build
+descriptor (`roles/services/<service>/files/<service>.json`). `build_release.yml`
+rebuilds each selected service from source **at the ref its descriptor records**,
+pushes to the registry, and rewrites the descriptor with the new digest. Because
+the ref comes from each descriptor, **`git_ref` is not an input here** — this
+reproduces the pinned release with fresh digests, rather than building an
+arbitrary ref (that's `build_it.yml`).
+
+**Run all commands from the `ansible/` directory.** This is build-only — it does
+not touch a cluster.
+
+## When to Use
+
+- Reproducing a whole release (or a subset) from source with fresh digests
+- Verifying that every service in a release still builds
+- NOT for building an arbitrary ref of one service (use
+  `building-de-service-images` / `build_it.yml` with `-e git_ref=...`)
+- NOT for deploying (use `deploying-de-services`)
+
+## Choosing the Inventory
+
+An `-i <inventory>` is required even though the build runs locally — the play
+targets `k8s_controllers[0]`. The inventory can also affect `image_registry` /
+`source_repo_dir` if its group_vars set them. Don't assume one:
+
+- If the request names an environment/inventory, or one was agreed earlier in
+  this session, use it.
+- Otherwise **ask the user which inventory to use before running.**
+
+## Quick Reference
+
+| Goal | Command |
+| --- | --- |
+| Rebuild the whole release | `ansible-playbook -i <inventory> build_release.yml` |
+| Rebuild a subset | `ansible-playbook -i <inventory> build_release.yml -e services=formation,apps` |
+| Verify the release builds (no push) | `ansible-playbook -i <inventory> build_release.yml -e push_images=false` |
+| Rebuild everything from scratch | `ansible-playbook -i <inventory> build_release.yml -e force_rebuild=true` |
+
+Subset selection is `-e services=<csv>`, **not** `--tags`. Unknown service names
+**hard-fail** the run up front (`Unknown service(s): …`), so a typo aborts rather
+than silently building nothing.
+
+## Variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `services` | all | Comma-separated subset to rebuild. |
+| `push_images` | `true` | Push and rewrite descriptors. When `false`, build only. |
+| `force_rebuild` | `false` | Bypass skaffold's artifact cache (`--cache-artifacts=false`). |
+| `image_registry` | `harbor.cyverse.org` | Target registry. |
+| `source_repo_dir` | dir containing this repo | Where source repos are checked out. Match the value you cloned into. |
+
+There is **no `git_ref`** — each service's ref is read from its descriptor.
+
+## What a Rebuild Does
+
+For each selected service, on localhost:
+
+1. Reads the ref from `roles/services/<service>/files/<service>.json` — anchored
+   on the image name, stripping `@sha256:<digest>` and any trailing `-dirty`
+   (skaffold's mark for an image built from an uncommitted tree), recovering the
+   clean tag. A descriptor with a **digest-only** tag yields no ref and the
+   service is **skipped** (not built from garbage) — e.g. `vice-operator`, which
+   reuses the `app-exposer` image.
+2. Builds that ref via the `build-service` role (temp git worktree, overlaid
+   skaffold/k8s, registry cache), pushes, and rewrites the descriptor with the
+   new digest (only when pushing).
+
+The run is **best-effort**: each service is wrapped in block/rescue, so a failure
+is recorded and the loop continues. At the end it prints a **rebuilt / skipped /
+failed** summary and **exits non-zero if any service failed**.
+
+## Prerequisites
+
+- **Docker** with BuildKit and **skaffold** on `PATH`.
+- Source repos cloned under `source_repo_dir` (`cloning-de-source-repos` /
+  `clone_sources.yml`). If you cloned elsewhere, pass the same
+  `-e source_repo_dir=<path>`.
+- For push builds, a `docker login` to the target registry already in place.
+
+## Common Mistakes
+
+- **Using `--tags` for a subset.** That's `build_it.yml`, whose `git_ref`
+  defaults to `main` — it would build main, not the pinned release ref. For a
+  release, use `build_release.yml -e services=<csv>`.
+- **Expecting `git_ref` to apply.** It's ignored here; the ref is the one
+  recorded in each descriptor.
+- **Expecting `push_images=false` to still push.** It doesn't — these services
+  build through the custom builder, which uses `docker buildx ... --load` when
+  not pushing. With `push_images=false` the descriptors are left untouched.
+- **Expecting a mid-run failure to roll back.** Services that succeeded before a
+  failure have **already pushed** their new digests and rewritten their
+  descriptors; those are not undone. Re-run with `-e services=<the failed ones>`
+  after fixing the cause.
+- **Expecting fresh digests to auto-deploy.** Descriptors are written into each
+  service role's own `files/` dir and are **never committed**. Deploys read from
+  `build_json_dir` (which an inventory may point at a separate `de-releases`
+  checkout), so publish/commit the updated descriptors before deploying.
+- **Treating skipped services as failures.** A digest-only descriptor (e.g.
+  `vice-operator`) is intentionally skipped, not failed.

--- a/skills/releasing-a-de-service/SKILL.md
+++ b/skills/releasing-a-de-service/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: releasing-a-de-service
+description: Use when cutting a release of a CyVerse DE service by pushing a git tag so the GitHub Actions pipeline builds the image and commits its build descriptor to the deployments repo — e.g. tagging a release candidate, promoting to a final release, or diagnosing why a tagged build didn't update a descriptor.
+---
+
+# Releasing a DE Service
+
+## Overview
+
+Pushing a version tag to a DE **service source repo** triggers its
+`skaffold-build` GitHub Actions workflow, which is the automated counterpart to
+a manual `build_it.yml` run. The workflow calls the shared reusable workflow
+`cyverse-de/github-workflows/.github/workflows/skaffold-build.yml@v0.4.0`, which:
+
+1. Checks out the service source repo **at the tag** and the `deployments` repo.
+2. Runs **this repo's** `ansible/build_it.yml` with `push_images=true` — the same
+   playbook the `building-de-service-images` skill documents.
+3. Pushes the image to Harbor and commits
+   `updated the build descriptor for <service>` to `cyverse-de/deployments`
+   (`ansible/roles/services/<service>/files/<service>.json`).
+
+So a release is: **tag the source repo → CI builds at that tag → a descriptor
+commit lands on `deployments` `main`.** Deploying that descriptor to a cluster
+is a separate step (`deploying-de-services`).
+
+## When to Use
+
+- Cutting a release candidate or final release of a service (tag → image +
+  descriptor commit).
+- Diagnosing why a tagged build failed or didn't update a descriptor.
+- NOT for a manual/local build of an arbitrary ref (that's
+  `building-de-service-images` / `build_it.yml -e git_ref=...`), which builds
+  locally and does **not** commit the descriptor.
+- NOT for rebuilding a whole release from recorded refs (`rebuilding-a-de-release`).
+- NOT for deploying (`deploying-de-services`).
+
+## Choosing the Tag
+
+The trigger regex is generic three-part semver, but DE tags encode the **date of
+the next scheduled release, which is NOT today's date**. Accepted forms:
+
+| Form | Meaning |
+| --- | --- |
+| `vYYYY.MM.DD-rcNN` | Release candidate for the release on `YYYY.MM.DD` (e.g. `v2026.08.04-rc02`) |
+| `vYYYY.MM.DD` | Final release |
+| `vYYYY.MM.DDuNN` | Update to an already-released milestone (not enabled in every repo) |
+
+**Release cadence: the first Tuesday of every month.** The date in the tag is the
+**next such release that hasn't happened yet**, so all work heading to that
+release shares one milestone date regardless of when it was tagged. Example: on
+2026-07-09 the July release (Tue 2026-07-07) has passed, so the next is Tue
+2026-08-04 — work tagged now uses `v2026.08.04-rc##`.
+
+Two phases:
+
+1. **During the month — tag release candidates.** Each change destined for the
+   upcoming release gets `vYYYY.MM.DD-rcNN`, incrementing `NN` for each new
+   candidate in that repo. Pick the next number by looking at what already
+   exists on the milestone:
+   ```
+   git -C <repo> tag -l "v2026.08.04*"     # existing candidates for this milestone
+   ```
+2. **The night before the release — promote to final.** Go through each repo that
+   has a release candidate for the upcoming release and tag its shipping commit
+   with the bare `vYYYY.MM.DD` (no `-rc`), e.g. `v2026.08.04`. That final tag
+   fires the same build and lands the released descriptor.
+
+If unsure which milestone is active or which commit to promote, ask — it's a
+release-planning decision, not one to guess.
+
+## Quick Reference
+
+Run against the **service source repo** (a sibling checkout), not `deployments`.
+
+| Goal | Command |
+| --- | --- |
+| Cut a release candidate | `git -C <repo> tag vYYYY.MM.DD-rcNN && git -C <repo> push origin vYYYY.MM.DD-rcNN` |
+| Cut a final release | `git -C <repo> tag vYYYY.MM.DD && git -C <repo> push origin vYYYY.MM.DD` |
+| Find the triggered run | `gh run list --repo cyverse-de/<repo> --workflow skaffold-build.yml --limit 1` |
+| Watch it to completion | `gh run watch <run-id> --repo cyverse-de/<repo> --exit-status` |
+| Confirm the descriptor landed | `gh api repos/cyverse-de/deployments/commits --jq '.[0].commit.message'` |
+
+The tag must be pushed to the source repo (that's what triggers the build and
+what gets built). The image is built from the tagged commit, so tag the commit
+you intend to ship.
+
+## What a Release Build Does
+
+The reusable workflow (`skaffold-build.yml@v0.4.0`), on a GitHub runner:
+
+1. Sets `SERVICE_NAME` to the caller's `service-name` input or, by default, the
+   repo name.
+2. Checks out the source repo at the tag and `deployments` at `main` (push
+   credentials come from `releases-repo-push-token`).
+3. **Verifies the service role exists** at
+   `deployments/ansible/roles/services/<service>` — hard-fails if absent (a new
+   service needs its role added first; see `adding-a-de-service-role`).
+4. Logs in to Harbor, installs skaffold + ansible, then runs
+   `build_it.yml --tags <service> -e git_ref=<tag> -e push_images=true`, building
+   from the source repo checkout and pushing the image.
+5. Commits the rewritten descriptor to `deployments`. The push **rebases onto the
+   latest tip and retries** (up to 5 attempts), so concurrent builds of different
+   services don't collide.
+
+## The Caller Workflow (reference)
+
+Each service repo has `.github/workflows/skaffold-build.yml` (one exception:
+`get-analysis-id` keeps its as the misnamed `swagger-build.yml`) that pins the
+reusable workflow and passes three secrets:
+
+```yaml
+jobs:
+  call-workflow-passing-data:
+    uses: cyverse-de/github-workflows/.github/workflows/skaffold-build.yml@v0.4.0
+    secrets:
+      harbor-username: ${{ secrets.HARBOR_USERNAME }}
+      harbor-password: ${{ secrets.HARBOR_PASSWORD }}
+      releases-repo-push-token: ${{ secrets.GH_DE_RELEASES_PUSH_TOKEN }}
+```
+
+`service-name`, `deployments-repo`, and `deployments-branch` are optional inputs
+(default to the repo name, `cyverse-de/deployments`, and `main`).
+
+## Prerequisites
+
+- The service has a role under `deployments/ansible/roles/services/<service>/`
+  whose name matches the repo name (or the caller passes a matching
+  `service-name`). Without it the build hard-fails at "Verify the service role
+  exists".
+- The org-level `GH_DE_RELEASES_PUSH_TOKEN` secret is valid (see Troubleshooting).
+- `gh` authenticated against `cyverse-de` for watching runs and reading commits.
+
+## Troubleshooting
+
+- **`Permission to cyverse-de/deployments.git denied … 403` on "Commit the
+  updated descriptor".** The image built fine; only the descriptor push was
+  blocked. The `GH_DE_RELEASES_PUSH_TOKEN` (an **org-level** Actions secret, so
+  fixing it once covers every repo) needs both **write access to
+  `cyverse-de/deployments`** and, for a classic PAT, **SSO authorization for the
+  `cyverse-de` org** (Token settings → Configure SSO → Authorize). A token whose
+  owner personally has repo access still 403s until the token itself is
+  SSO-authorized — the classic "my account works but the token doesn't" trap.
+- **`! [rejected] main -> main (fetch first)` on the descriptor push.** This is
+  the concurrent-push race, fixed in `v0.4.0` by the rebase-and-retry loop. If
+  you see it again, the fix regressed — check that the `v0.4.0` tag in
+  `github-workflows` still points at the fixed commit. Meanwhile, re-run the
+  failed job on its own; the image is already in Harbor, so only the descriptor
+  commit needs to land.
+- **Build succeeded but no descriptor commit appeared.** If the descriptor was
+  already current for that ref, the step logs `descriptor unchanged; nothing to
+  commit` and exits cleanly — that's expected, not a failure.
+
+## Common Mistakes
+
+- **Using today's date for the tag.** The date is the next scheduled release
+  (first Tuesday of the month), not the calendar day. Check existing tags and
+  continue that milestone's `-rcNN` sequence.
+- **Tagging `vice-operator`.** It has no source repo of its own — it's built from
+  the `app-exposer` repo. Release it by tagging `app-exposer`.
+- **Expecting a manual `build_it.yml` run to publish a release.** A local build
+  never commits the descriptor; only the tag-triggered CI run does. Use a manual
+  build to verify a service compiles, and a tag to actually release it.
+- **Tagging a service with no deployments role.** The build hard-fails up front.
+  Add the role first (`adding-a-de-service-role`).
+- **Confusing this with deploying.** A green release only lands a descriptor
+  commit on `deployments` `main`; nothing reaches a cluster until a separate
+  deploy (`deploying-de-services`).

--- a/skills/resolving-the-kubeconfig/SKILL.md
+++ b/skills/resolving-the-kubeconfig/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: resolving-the-kubeconfig
+description: Use when a CyVerse DE deployments command needs to know which cluster to act on — before running any ansible-playbook, kubectl, or skaffold that targets a cluster (deploys, subsystem installs, full kubernetes.yml runs). Resolves the kubeconfig value and decides when to ask the user.
+---
+
+# Resolving the Kubeconfig
+
+## Overview
+
+Many `deployments` operations act on a Kubernetes cluster and read the Ansible
+`kubeconfig` var to decide **which** cluster. Its role default
+(`roles/common/defaults/main.yml`) reads the `KUBECONFIG` env var, falling back
+to `~/.kube/config`:
+
+```yaml
+kubeconfig: "{{ lookup('env', 'KUBECONFIG') | default(lookup('env','HOME') ~ '/.kube/config', true) }}"
+```
+
+But an inventory's group_vars may **pin `kubeconfig` explicitly**, and a
+group_vars value **wins over the env-derived default**. So `KUBECONFIG` alone
+does not guarantee the cluster you'll hit — resolve the value deliberately
+before running anything that mutates a cluster.
+
+## When to Use
+
+- Before any command that targets a cluster: `deploy_it.yml`, `kubernetes.yml`,
+  a subsystem install, or a direct `kubectl`/`skaffold` against the DE.
+- Any skill that deploys or mutates cluster state should resolve the kubeconfig
+  through this procedure first.
+- NOT needed for build-only work (`build_it.yml` / `build_release.yml` don't
+  touch a cluster).
+
+## The Three Sources
+
+| | Source | How to observe it |
+| --- | --- | --- |
+| **S** | A kubeconfig agreed earlier in **this session** | Conversation context |
+| **G** | `kubeconfig` pinned in the inventory **group_vars** | Grep the `-i` inventory's group_vars for a `kubeconfig:` line |
+| **E** | The `KUBECONFIG` **environment** variable | `printenv KUBECONFIG` |
+
+## Resolution
+
+| Situation | Do this |
+| --- | --- |
+| **S** is set | Use S — a session-agreed value wins over G and E. |
+| S unset, exactly one of **G** / **E** set | Use whichever is set. |
+| S unset, **both G and E** set | They may disagree (and G silently wins in Ansible). **Ask** which to use. |
+| S unset, **neither** G nor E set (only the `~/.kube/config` fallback) | **Ask** for the kubeconfig — do not act against the default. |
+
+Whenever you ask, also ask **whether the chosen value should apply to the rest
+of the session**; if so, treat it as **S** for later commands. **Do not write
+the kubeconfig to memory** — it changes across sessions.
+
+When S is set but the environment doesn't yet reflect it (e.g. `KUBECONFIG`
+points elsewhere), make the `kubeconfig` var actually resolve to S before
+running — e.g. `export KUBECONFIG=<agreed path>`.
+
+## Guardrail
+
+If the resolved kubeconfig targets **production**, get **explicit approval**
+before running any mutating command — never default to prod.
+
+## Common Mistakes
+
+- **Trusting `KUBECONFIG` when group_vars pins `kubeconfig`.** The group_vars
+  value wins; the export is silently ignored. Check G before assuming E applies.
+- **Proceeding on the `~/.kube/config` fallback.** If nothing selects a cluster,
+  ask — don't let a mutating command land on whatever `~/.kube/config` happens
+  to be.
+- **Persisting the value.** Keep the resolved kubeconfig as session state only;
+  never save it to memory.


### PR DESCRIPTION
Adds a `skills/` collection documenting the operational workflows around the `deployments` repo. Each skill is a self-contained `SKILL.md`.

| Skill | Covers |
| --- | --- |
| `adding-a-de-service-role` | Adding a new service's role under `ansible/roles/services/` |
| `cloning-de-source-repos` | Cloning the sibling service source repos (`clone_sources.yml`) |
| `building-de-service-images` | Building/verifying a service image from source via `build_it.yml` |
| `rebuilding-a-de-release` | Rebuilding a release's images at their pinned refs via `build_release.yml` |
| `releasing-a-de-service` | The tag-triggered CI release path (push a `vYYYY.MM.DD-rcNN` tag → `github-workflows` builds the image and commits the descriptor here) |
| `deploying-de-services` | Deploying services to a cluster (`deploy_it.yml`) |
| `resolving-the-kubeconfig` | Resolving the kubeconfig for a target environment |

`releasing-a-de-service` is new; it documents the automated release pipeline (tag conventions tied to the first-Tuesday-of-the-month cadence, the reusable-workflow flow, the descriptor commit, and token/SSO + concurrency troubleshooting) as the counterpart to the manual `build_it.yml` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)