### PR TITLE
Drop NATS wiring from the app-exposer deployment

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -117,6 +117,7 @@ baseurls_permissions: http://permissions
 baseurls_qms: http://qms
 baseurls_requests: http://requests
 baseurls_search: http://search
+baseurls_subscriptions: http://subscriptions
 baseurls_terrain: http://terrain
 baseurls_user_info: http://user-info
 

--- a/ansible/roles/services/app-exposer/templates/app-exposer.yml.j2
+++ b/ansible/roles/services/app-exposer/templates/app-exposer.yml.j2
@@ -89,6 +89,9 @@ qms:
   base: "{{ baseurls_qms|string|regex_replace("\/$","") }}"
   usage: "/v1/admin/usages"
 
+subscriptions:
+  base: "{{ baseurls_subscriptions|string|regex_replace("\/$","") }}"
+
 tickets_path_list:
   file_identifier: "# application/vnd.de.tickets-path-list+csv; version=1"
 

--- a/ansible/roles/services/app-exposer/templates/k8s/app-exposer.yml.j2
+++ b/ansible/roles/services/app-exposer/templates/k8s/app-exposer.yml.j2
@@ -34,12 +34,6 @@ spec:
             items:
               - key: app-exposer.yml
                 path: service.yml
-        - name: nats-client-tls
-          secret:
-            secretName: nats-client-tls
-        - name: nats-services-creds
-          secret:
-            secretName: nats-services-creds
       containers:
         - name: app-exposer
           image: harbor.cyverse.org/de/app-exposer
@@ -88,11 +82,6 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: OTEL_EXPORTER_JAEGER_HTTP_ENDPOINT
-            - name: DISCOENV_NATS_CLUSTER
-              valueFrom:
-                secretKeyRef:
-                  name: configs
-                  key: NATS_URLS
             - name: CLUSTER_CONFIG_SECRET
               valueFrom:
                 secretKeyRef:
@@ -104,12 +93,6 @@ spec:
           volumeMounts:
             - name: app-exposer-configs
               mountPath: /etc/cyverse/de/configs
-              readOnly: true
-            - name: nats-client-tls
-              mountPath: /etc/nats/tls
-              readOnly: true
-            - name: nats-services-creds
-              mountPath: /etc/nats/creds
               readOnly: true
           livenessProbe:
             httpGet:

--- a/docs/certificate-management.md
+++ b/docs/certificate-management.md
@@ -237,7 +237,7 @@ self-signed certificates. To extract them for debugging or out-of-cluster use, s
 [nats.md](nats.md).
 
 If the NATS certificates expire, services that connect to NATS (subscriptions, terrain,
-app-exposer, jex-adapter, discoenv-analyses, discoenv-users, data-usage-api,
+jex-adapter, discoenv-analyses, discoenv-users, data-usage-api,
 resource-usage-api) will fail to connect. Symptoms: services log TLS
 handshake errors; NATS-dependent operations silently fail.
 
@@ -253,7 +253,6 @@ After renewal, restart all NATS-connected services so they pick up the new certi
 
 ```bash
 kubectl -n $NS rollout restart \
-  deployment/app-exposer \
   deployment/data-usage-api \
   deployment/discoenv-analyses \
   deployment/discoenv-users \

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-22
 
+* **Update**: [app-exposer](/services/app-exposer.md) and [Certificate Management](/playbooks/certificate-management.md) — app-exposer no longer uses NATS; it now performs user overage checks against [subscriptions](/services/subscriptions.md) over HTTP (`GET /users/{username}/overages`), so it was removed from the NATS cert-renewal consumer list and restart command.
 * **Update**: [Miscellaneous Utility Playbooks](/playbooks/misc-utility-playbooks.md) and [openldap-docker](/services/openldap-docker.md) — documented the new `openldap_community_group.yml` playbook that backfills the `community` group on already-deployed OpenLDAP instances (the seed LDIF only loads on a fresh volume).
 
 ## 2026-07-21

--- a/wiki/playbooks/certificate-management.md
+++ b/wiki/playbooks/certificate-management.md
@@ -4,7 +4,7 @@ title: Certificate Management
 description: TLS certificate inventory for the DE, how certs are issued and renewed, and what to do when one has expired or is about to.
 resource: /docs/certificate-management.md
 tags: [tls, certificates, cert-manager, letsencrypt, haproxy, nats, keycloak]
-timestamp: 2026-07-20T00:00:00Z
+timestamp: 2026-07-22T00:00:00Z
 ---
 
 This runbook covers the TLS certificates used by the DE, how they are issued and renewed,
@@ -234,7 +234,7 @@ self-signed certificates. To extract them for debugging or out-of-cluster use, s
 
 If the NATS certificates expire, services that connect to NATS
 ([subscriptions](/services/subscriptions.md), [terrain](/services/terrain.md),
-[app-exposer](/services/app-exposer.md), [jex-adapter](/services/jex-adapter.md),
+[jex-adapter](/services/jex-adapter.md),
 [discoenv-analyses](/services/discoenv-analyses.md),
 [discoenv-users](/services/discoenv-users.md),
 [data-usage-api](/services/data-usage-api.md),
@@ -253,7 +253,6 @@ After renewal, restart all NATS-connected services so they pick up the new certi
 
 ```bash
 kubectl -n $NS rollout restart \
-  deployment/app-exposer \
   deployment/data-usage-api \
   deployment/discoenv-analyses \
   deployment/discoenv-users \

--- a/wiki/services/app-exposer.md
+++ b/wiki/services/app-exposer.md
@@ -3,8 +3,8 @@ type: Service
 title: app-exposer
 description: In-cluster API that launches and manages VICE and batch analyses, exposing them via Kubernetes resources.
 resource: /ansible/roles/services/app-exposer
-tags: [app-exposer, vice, batch, kubernetes, amqp, nats]
-timestamp: 2026-07-20T00:00:00Z
+tags: [app-exposer, vice, batch, kubernetes, amqp]
+timestamp: 2026-07-22T00:00:00Z
 ---
 
 app-exposer is the DE's job-orchestration API inside the cluster. Its config
@@ -18,8 +18,9 @@ client), [Harbor](/infrastructure/harbor.md) robot credentials, a
 [notifications](/services/notifications.md),
 [iplant-groups](/services/iplant-groups.md),
 [job-status-listener](/services/job-status-listener.md),
-[qms](/services/qms.md), and iplant-email. The pod also mounts NATS client TLS
-and creds secrets and reads `NATS_URLS` for [NATS](/infrastructure/nats.md).
+[qms](/services/qms.md), [subscriptions](/services/subscriptions.md) (user
+overage checks via `GET /users/{username}/overages` before analysis launches),
+and iplant-email. app-exposer does not use [NATS](/infrastructure/nats.md).
 The config also names the porklock data-transfer image, and its VICE section
 covers the gateway provider, base domain, file-transfers image, and the
 default backend loading page.
@@ -52,6 +53,6 @@ See [Building and Deploying Services](/playbooks/build-and-deploy.md).
 
 1. `ansible/roles/services/app-exposer/templates/app-exposer.yml.j2` — config template listing AMQP, DB, iRODS, Keycloak, Harbor, and service URLs.
 2. `ansible/roles/services/app-exposer/tasks/main.yml` — service accounts, RBAC, config secret, and deploy-service include.
-3. `ansible/roles/services/app-exposer/templates/k8s/app-exposer.yml.j2` — deployment with NATS TLS/creds mounts and env wiring.
+3. `ansible/roles/services/app-exposer/templates/k8s/app-exposer.yml.j2` — deployment manifest with env wiring and config mounts.
 4. `ansible/roles/services/app-exposer/files/app-exposer.json` — build descriptor pinning the image.
 5. `ansible/roles/services/app-exposer/defaults/main.yml` — replica and anti-affinity defaults.


### PR DESCRIPTION
## Summary

- app-exposer now fetches user overages from the subscriptions service over HTTP (`GET /users/{username}/overages`) instead of NATS — see cyverse-de/app-exposer#161.
- Removes the `nats-client-tls`/`nats-services-creds` volumes+mounts and the `DISCOENV_NATS_CLUSTER` env var from the app-exposer deployment template.
- Adds `subscriptions.base` to the app-exposer service config and a `baseurls_subscriptions: http://subscriptions` common default (additive; matches the binary's built-in default).
- Wiki + docs: app-exposer removed from the NATS consumer lists and cert-renewal restart commands in `wiki/playbooks/certificate-management.md` and `docs/certificate-management.md`; its service page now names the subscriptions dependency. `okf check`: 0 errors, 0 warnings.

## Rollout order

**Do not deploy this against an app-exposer image older than cyverse-de/app-exposer#161** — the old binary exits at startup when `DISCOENV_NATS_CLUSTER` is unset. Release and deploy the new image first (it ignores the still-mounted NATS secrets), verify a VICE/batch launch performs the overage check, then apply this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)