### PR TITLE
Remove NATS from the usage-api deployments

### DIFF
--- a/ansible/roles/services/data-usage-api/templates/k8s/data-usage-api.yml.j2
+++ b/ansible/roles/services/data-usage-api/templates/k8s/data-usage-api.yml.j2
@@ -34,17 +34,6 @@ spec:
             items:
               - key: data-usage-api.yml
                 path: data-usage-api.yml
-        - name: nats-client-tls
-          secret:
-            secretName: nats-client-tls
-        - name: nats-services-creds
-          secret:
-            secretName: nats-services-creds
-            items:
-              - key: services.creds
-                path: services.creds
-              - key: services.creds
-                path: service.creds
       containers:
         - name: data-usage-api
           image: harbor.cyverse.org/de/data-usage-api
@@ -73,23 +62,15 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: OTEL_EXPORTER_JAEGER_HTTP_ENDPOINT
-            - name: DISCOENV_NATS_CLUSTER
-              valueFrom:
-                secretKeyRef:
-                  name: configs
-                  key: NATS_URLS
+          args:
+            - --subscriptions-base-uri
+            - {{ baseurls_subscriptions }}
           ports:
             - name: listen-port
               containerPort: 60000
           volumeMounts:
             - name: data-usage-api-configs
               mountPath: /etc/iplant/de
-              readOnly: true
-            - name: nats-client-tls
-              mountPath: /etc/nats/tls
-              readOnly: true
-            - name: nats-services-creds
-              mountPath: /etc/nats/creds
               readOnly: true
           livenessProbe:
             httpGet:

--- a/ansible/roles/services/resource-usage-api/templates/k8s/resource-usage-api.yml.j2
+++ b/ansible/roles/services/resource-usage-api/templates/k8s/resource-usage-api.yml.j2
@@ -34,19 +34,6 @@ spec:
             items:
               - key: jobservices.yml
                 path: service.yml
-        - name: nats-client-tls
-          secret:
-            secretName: nats-client-tls
-        - name: nats-services-creds
-          secret:
-            secretName: nats-services-creds
-            items:
-              - key: services.creds
-                path: services.creds
-              - key: services.creds
-                path: service.creds
-        - name: nats-configuration
-          emptyDir: {}
       containers:
         - name: resource-usage-api
           image: harbor.cyverse.org/de/resource-usage-api
@@ -75,29 +62,17 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: OTEL_EXPORTER_JAEGER_HTTP_ENDPOINT
-            - name: DISCOENV_NATS_CLUSTER
-              valueFrom:
-                secretKeyRef:
-                  name: configs
-                  key: NATS_URLS
           args:
             - --log-level
             - debug
+            - --subscriptions-base-uri
+            - {{ baseurls_subscriptions }}
           ports:
             - name: listen-port
               containerPort: 60000
           volumeMounts:
             - name: resource-usage-api-configs
               mountPath: /etc/cyverse/de/configs
-              readOnly: true
-            - name: nats-client-tls
-              mountPath: /etc/nats/tls
-              readOnly: true
-            - name: nats-services-creds
-              mountPath: /etc/nats/creds
-              readOnly: true
-            - name: nats-configuration
-              mountPath: /etc/cyverse/de/env
               readOnly: true
           livenessProbe:
             httpGet:

--- a/docs/certificate-management.md
+++ b/docs/certificate-management.md
@@ -236,10 +236,11 @@ NATS uses its own client and server TLS certificates. These are cert-manager-man
 self-signed certificates. To extract them for debugging or out-of-cluster use, see
 [nats.md](nats.md).
 
-If the NATS certificates expire, services that connect to NATS (subscriptions,
-data-usage-api,
-resource-usage-api) will fail to connect. Symptoms: services log TLS
-handshake errors; NATS-dependent operations silently fail.
+subscriptions is the only remaining service that connects to NATS. If the NATS
+certificates expire it will fail to connect; symptoms are TLS handshake errors
+in its logs. Its HTTP API is unaffected, and since every remaining caller —
+terrain, data-usage-api, and resource-usage-api — now uses that HTTP API, an
+expired NATS certificate no longer breaks QMS operations.
 
 To renew:
 
@@ -249,13 +250,10 @@ kubectl -n $NS delete secret nats-client-tls nats-server-tls
 kubectl -n $NS get certificate | grep nats -w
 ```
 
-After renewal, restart all NATS-connected services so they pick up the new certificates:
+After renewal, restart subscriptions so it picks up the new certificates:
 
 ```bash
-kubectl -n $NS rollout restart \
-  deployment/data-usage-api \
-  deployment/resource-usage-api \
-  deployment/subscriptions
+kubectl -n $NS rollout restart deployment/subscriptions
 ```
 
 ---

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,9 @@
 # Wiki Update Log
 
+## 2026-07-24
+
+* **Update**: [data-usage-api](/services/data-usage-api.md) and [resource-usage-api](/services/resource-usage-api.md) — both now reach [subscriptions](/services/subscriptions.md) over HTTP instead of NATS, so removed their NATS secret mounts, the `nats-configuration` volume, and the `DISCOENV_NATS_CLUSTER` env from the deployments, passing `--subscriptions-base-uri` (from `baseurls_subscriptions`) instead. Rewrote [Certificate Management](/playbooks/certificate-management.md)'s NATS section: subscriptions is now the only NATS consumer, and since every caller uses its HTTP API, an expired NATS certificate no longer breaks QMS operations.
+
 ## 2026-07-23
 
 * **Removal**: Deleted the qms-adapter service page — the service was retired from the repo. Nothing publishes to the `qms.usages` AMQP routing key it consumed; usage updates moved to NATS and the [subscriptions](/services/subscriptions.md) service in 2022. Dropped the cross-reference and the stale "exchanging updates over AMQP" description from [qms](/services/qms.md), and documented the new `qms_adapter_cleanup.yml` in [Miscellaneous Utility Playbooks](/playbooks/misc-utility-playbooks.md).

--- a/wiki/playbooks/certificate-management.md
+++ b/wiki/playbooks/certificate-management.md
@@ -232,11 +232,13 @@ NATS uses its own client and server TLS certificates. These are cert-manager-man
 self-signed certificates. To extract them for debugging or out-of-cluster use, see
 [NATS](/infrastructure/nats.md).
 
-If the NATS certificates expire, services that connect to NATS
-([subscriptions](/services/subscriptions.md),
-[data-usage-api](/services/data-usage-api.md),
-[resource-usage-api](/services/resource-usage-api.md)) will fail to connect. Symptoms:
-services log TLS handshake errors; NATS-dependent operations silently fail.
+[subscriptions](/services/subscriptions.md) is the only remaining service that
+connects to NATS. If the NATS certificates expire it will fail to connect;
+symptoms are TLS handshake errors in its logs. Its HTTP API is unaffected, and
+since every remaining caller — [terrain](/services/terrain.md),
+[data-usage-api](/services/data-usage-api.md), and
+[resource-usage-api](/services/resource-usage-api.md) — now uses that HTTP API,
+an expired NATS certificate no longer breaks QMS operations.
 
 To renew:
 
@@ -246,13 +248,10 @@ kubectl -n $NS delete secret nats-client-tls nats-server-tls
 kubectl -n $NS get certificate | grep nats -w
 ```
 
-After renewal, restart all NATS-connected services so they pick up the new certificates:
+After renewal, restart subscriptions so it picks up the new certificates:
 
 ```bash
-kubectl -n $NS rollout restart \
-  deployment/data-usage-api \
-  deployment/resource-usage-api \
-  deployment/subscriptions
+kubectl -n $NS rollout restart deployment/subscriptions
 ```
 
 ## 7. What to do when a certificate has already expired

--- a/wiki/playbooks/certificate-management.md
+++ b/wiki/playbooks/certificate-management.md
@@ -4,7 +4,7 @@ title: Certificate Management
 description: TLS certificate inventory for the DE, how certs are issued and renewed, and what to do when one has expired or is about to.
 resource: /docs/certificate-management.md
 tags: [tls, certificates, cert-manager, letsencrypt, haproxy, nats, keycloak]
-timestamp: 2026-07-23T00:00:00Z
+timestamp: 2026-07-24T00:00:00Z
 ---
 
 This runbook covers the TLS certificates used by the DE, how they are issued and renewed,

--- a/wiki/services/data-usage-api.md
+++ b/wiki/services/data-usage-api.md
@@ -1,10 +1,10 @@
 ---
 type: Service
 title: data-usage-api
-description: Reports per-user data-store usage by querying the ICAT database, serving results over HTTP and NATS.
+description: Reports per-user data-store usage by querying the ICAT database, serving results over HTTP.
 resource: /ansible/roles/services/data-usage-api
-tags: [data, usage, quotas, icat, nats, de]
-timestamp: 2026-07-20T00:00:00Z
+tags: [data, usage, quotas, icat, de]
+timestamp: 2026-07-24T00:00:00Z
 ---
 
 data-usage-api computes data-store usage numbers. Its config gives it two
@@ -12,11 +12,10 @@ data-usage-api computes data-store usage numbers. Its config gives it two
 the ICAT database — with the ICAT side scoped to the root resources in
 `irods_quota_root_resources` (default `mainIngestRes,mainReplRes`) for the
 zone `irods_zone`. It also connects to the DE
-[RabbitMQ](/infrastructure/rabbitmq.md) `de` topic exchange and to
-[NATS](/infrastructure/nats.md): the pod mounts the `nats-client-tls` and
-`nats-services-creds` secrets and reads the cluster URLs from the
-`DISCOENV_NATS_CLUSTER` env var (sourced from the `configs` secret).
-Usernames are qualified with `uid_domain`.
+[RabbitMQ](/infrastructure/rabbitmq.md) `de` topic exchange, and it reads and
+records QMS usage by calling [subscriptions](/services/subscriptions.md) over
+HTTP at `--subscriptions-base-uri` (`baseurls_subscriptions`, default
+`http://subscriptions`). Usernames are qualified with `uid_domain`.
 
 - Source: [cyverse-de/data-usage-api](https://github.com/cyverse-de/data-usage-api); image `harbor.cyverse.org/de/data-usage-api` from [Harbor](/infrastructure/harbor.md), pinned by digest in the build descriptor.
 - Config: `data-usage-api.yml.j2` is templated into the `data-usage-api-configs` secret and mounted at `/etc/iplant/de/data-usage-api.yml`. Notable vars: `dbms_connection_*`, `icat_*`, `irods_quota_root_resources`, `de_amqp_*`, `uid_domain`.
@@ -30,6 +29,6 @@ data-usage-api` — see
 
 1. `ansible/roles/services/data-usage-api/templates/data-usage-api.yml.j2` — DE/ICAT DB URIs, root resources, AMQP exchange, uid domain.
 2. `ansible/roles/services/data-usage-api/files/data-usage-api.json` — pinned image name and digest.
-3. `ansible/roles/services/data-usage-api/templates/k8s/data-usage-api.yml.j2` — NATS TLS/creds mounts, `DISCOENV_NATS_CLUSTER`, service account, probes.
+3. `ansible/roles/services/data-usage-api/templates/k8s/data-usage-api.yml.j2` — `--subscriptions-base-uri` arg, service account, probes.
 4. `ansible/roles/services/data-usage-api/tasks/main.yml` — creates the `data-usage-api-configs` secret, then runs deploy-service.
 5. `ansible/roles/common/defaults/main.yml` — `irods_quota_root_resources` default.

--- a/wiki/services/index.md
+++ b/wiki/services/index.md
@@ -10,7 +10,7 @@
 * [clockwork](/services/clockwork.md) - Scheduler that triggers recurring DE jobs, notably infosquito indexing, publishing over AMQP and reading iRODS.
 * [dashboard-aggregator](/services/dashboard-aggregator.md) - Aggregates the data shown on the DE dashboard — news/event feeds, videos, and app information such as favorites and featured apps.
 * [data-info](/services/data-info.md) - HTTP API for data-store operations — file and folder metadata, permissions, path lists, and anonymous-access URLs backed by iRODS.
-* [data-usage-api](/services/data-usage-api.md) - Reports per-user data-store usage by querying the ICAT database, serving results over HTTP and NATS.
+* [data-usage-api](/services/data-usage-api.md) - Reports per-user data-store usage by querying the ICAT database, serving results over HTTP.
 * [de-mailer](/services/de-mailer.md) - Sends DE email notifications, building links from the DE base URL and relaying through an in-cluster Exim SMTP host.
 * [de-webhooks](/services/de-webhooks.md) - Consumes DE notification messages from RabbitMQ and forwards them to users' configured webhook endpoints.
 * [dewey](/services/dewey.md) - Indexes data-store changes into OpenSearch by consuming iRODS change messages from the irods AMQP exchange.
@@ -35,7 +35,7 @@
 * [portal2](/services/portal2.md) - The CyVerse user portal web application, handling account self-registration, sessions, and service access via Keycloak, portal-conductor, and terrain.
 * [qms](/services/qms.md) - The Quota Management Service, tracking subscription plans and resource usage in its own PostgreSQL database.
 * [requests](/services/requests.md) - HTTP service for administrative requests in the DE, backed by the DE database via the shared jobservices configuration.
-* [resource-usage-api](/services/resource-usage-api.md) - HTTP API for DE resource usage data, connected to NATS with TLS and service credentials and to the DE database.
+* [resource-usage-api](/services/resource-usage-api.md) - HTTP API for DE resource usage data, backed by the DE database and the subscriptions service.
 * [search](/services/search.md) - Search API that queries the data-store Elasticsearch/OpenSearch index and consults data-info for path information.
 * [sonora](/services/sonora.md) - The Discovery Environment web user interface, a Node.js app that fronts terrain and Keycloak.
 * [subscriptions](/services/subscriptions.md) - QMS subscription service that answers subscription requests over NATS and HTTP, backed by the QMS database.

--- a/wiki/services/resource-usage-api.md
+++ b/wiki/services/resource-usage-api.md
@@ -1,17 +1,19 @@
 ---
 type: Service
 title: resource-usage-api
-description: HTTP API for DE resource usage data, connected to NATS with TLS and service credentials and to the DE database.
+description: HTTP API for DE resource usage data, backed by the DE database and the subscriptions service.
 resource: /ansible/roles/services/resource-usage-api
-tags: [resource-usage, nats, postgresql, usage, http]
-timestamp: 2026-07-20T00:00:00Z
+tags: [resource-usage, postgresql, usage, http]
+timestamp: 2026-07-24T00:00:00Z
 ---
 
-An HTTP API over DE resource usage data. It is one of the
-[NATS](/infrastructure/nats.md)-connected services: the pod mounts the
-`nats-client-tls` and `nats-services-creds` secrets under `/etc/nats/` and
-gets the cluster URLs from `DISCOENV_NATS_CLUSTER` (the `NATS_URLS` key of the
-shared `configs` secret). The source repo is
+An HTTP API over DE resource usage data. It consumes analysis status events
+from [RabbitMQ](/infrastructure/rabbitmq.md), computes CPU hours per analysis,
+and records them against QMS by calling
+[subscriptions](/services/subscriptions.md) over HTTP at
+`--subscriptions-base-uri` (`baseurls_subscriptions`, default
+`http://subscriptions`) — the same base URL its `/summary` handler uses. The
+source repo is
 [cyverse-de/resource-usage-api](https://github.com/cyverse-de/resource-usage-api)
 and the image is `harbor.cyverse.org/de/resource-usage-api`, pinned in
 `ansible/roles/services/resource-usage-api/files/resource-usage-api.json`.
@@ -29,7 +31,8 @@ exchange URI (`de_amqp_*`), the `qms` section (`baseurls_qms`,
 
 Runtime: a Deployment with `resource_usage_api_replicas` (default 2), optional
 pod anti-affinity, and the `configurator` service account, run with
-`--log-level debug`, listening on port 60000 behind a `resource-usage-api`
+`--log-level debug` and `--subscriptions-base-uri`, listening on port 60000
+behind a `resource-usage-api`
 Service on port 80, with probes on `/`. OpenTelemetry tracing goes to
 [Jaeger](/infrastructure/jaeger.md).
 
@@ -39,7 +42,7 @@ Build and deploy with
 
 # Citations
 
-[1] `ansible/roles/services/resource-usage-api/templates/k8s/resource-usage-api.yml.j2` — NATS TLS/creds mounts, env, ports, service account.
+[1] `ansible/roles/services/resource-usage-api/templates/k8s/resource-usage-api.yml.j2` — `--subscriptions-base-uri` arg, env, ports, service account.
 [2] `ansible/roles/services/resource-usage-api/templates/jobservices.yml.j2` — shared config: DB URIs, AMQP, qms section.
 [3] `ansible/roles/services/resource-usage-api/tasks/main.yml` — config secret rendering and deploy.
 [4] `ansible/roles/services/resource-usage-api/files/resource-usage-api.json` — pinned image.


### PR DESCRIPTION
Part 3 of finishing the NATS removal (see `notes/nats-removal-finish-plan.md`). Ships with cyverse-de/resource-usage-api#23 and cyverse-de/data-usage-api#21.

## What this does

Both usage-APIs now reach `subscriptions` over HTTP, so neither needs the `nats-client-tls` / `nats-services-creds` secret mounts, the `nats-configuration` volume, or `DISCOENV_NATS_CLUSTER`. Each is passed `--subscriptions-base-uri` from `baseurls_subscriptions` instead.

That variable already exists (`roles/common/defaults/main.yml:119`, added for terrain's migration) and matches the flag default baked into both services, so passing it explicitly is belt-and-braces rather than newly required — but it keeps the base URL in one place alongside terrain's.

## ⚠️ Deploy ordering

**Deploy the new usage-API images before applying this.** The currently-deployed images `log.Fatal` at startup when `nats.cluster` is unset, so removing `DISCOENV_NATS_CLUSTER` from under an old image will crash-loop it.

## Deliberately not touched

`nats_urls` and the `NATS_URLS` injection in `service_configurations` stay — `subscriptions` still subscribes to `cyverse.qms.>`. Those come out in the Phase 5 teardown, after subscriptions drops its NATS server.

## Wiki

Refreshed the two service pages and rewrote Certificate Management's NATS section. That section previously told operators to restart all three services after a NATS cert renewal; now subscriptions is the only NATS consumer, and — worth noting for on-call — since terrain and both usage-APIs use its HTTP API, **an expired NATS certificate no longer breaks QMS operations at all**. Mirrored into `docs/certificate-management.md`.

`okf index` + `okf check`: **0 errors, 0 warnings** across 87 files.

## Testing

Rendered both templates through Jinja2 and parsed the output as YAML — both produce valid manifests with no NATS volumes, mounts, or env, and the expected args:

- `data-usage-api`: `['--subscriptions-base-uri', 'http://subscriptions']`
- `resource-usage-api`: `['--log-level', 'debug', '--subscriptions-base-uri', 'http://subscriptions']`

After deploying, confirm neither pod has `/etc/nats/*` mounts and drive a usage lookup and a data-usage refresh end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
