### PR TITLE
Scope the locale pre-flight to the runs that create databases

### DIFF
--- a/ansible/roles/postgresql_init/tasks/main.yml
+++ b/ansible/roles/postgresql_init/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check for databases this role cannot reconcile
   ansible.builtin.include_tasks: preflight.yml
-  tags:
-    - update-databases
 
 - name: Prepare for database work
   ansible.builtin.include_role:

--- a/ansible/roles/postgresql_init/tasks/preflight.yml
+++ b/ansible/roles/postgresql_init/tasks/preflight.yml
@@ -7,21 +7,16 @@
 # Once per database server: Keycloak's may not be on the same one, and a
 # database absent from the server being queried just does not come back.
 #
-# apply: is required, not stylistic. A dynamic include's tags only decide
-# whether the file is included; the tasks inside keep their own tags, which is
-# none, so under --tags update-databases the include would run and every task
-# in it would be filtered out — a pre-flight that silently checks nothing.
-# delegate_to lives in the included file, since an include cannot carry it.
+# Deliberately untagged, so it inherits only the play's tags and runs when the
+# postgresql_db tasks it guards do. Those tasks carry no update-databases tag,
+# so a --tags update-databases run never touches a locale provider; tagging
+# this check would abort migration-only runs over a mismatch nothing in scope
+# was going to attempt to reconcile. delegate_to lives in the included file,
+# since an include cannot carry it.
 - name: Check the locale provider on any pre-existing DE databases
-  ansible.builtin.include_tasks:
-    file: preflight_server.yml
-    apply:
-      tags:
-        - update-databases
+  ansible.builtin.include_tasks: preflight_server.yml
   when: create_dbs is defined and create_dbs
   loop: "{{ postgresql_init_preflight_targets }}"
   loop_control:
     loop_var: postgresql_init_target
     label: "{{ postgresql_init_target.host }}"
-  tags:
-    - update-databases

--- a/wiki/infrastructure/postgresql.md
+++ b/wiki/infrastructure/postgresql.md
@@ -4,7 +4,7 @@ title: PostgreSQL
 description: How PostgreSQL is installed and the DE databases are initialized by the install-postgres and setup-databases passes of kubernetes.yml, plus day-to-day operations such as backups, manual migrations, and diagnostics.
 resource: /docs/postgresql.md
 tags: [postgresql, database, kubernetes.yml]
-timestamp: 2026-07-31T12:00:00Z
+timestamp: 2026-08-04T12:00:00Z
 ---
 
 PostgreSQL is installed and initialized as part of the `kubernetes.yml`
@@ -103,6 +103,19 @@ permissions or version problem rather than a stale database. `postgresql_init`
 checks `datlocprovider` up front and fails naming the offending databases. The
 check runs only when `create_dbs` is set, so an environment that does not
 create databases is unaffected by ones predating the switch.
+
+Its scope is the runs that create databases, and nothing more. The check
+carries no tags of its own, so it inherits the play's `setup-databases` and
+`databases` and is filtered out of a `--tags update-databases` run — which is
+correct, because every `postgresql_db` task it guards is untagged too and so
+is filtered out of that run as well. Tagging the check would abort a
+migrations-only pass over a locale mismatch that nothing in scope was going to
+try to reconcile. This matters on an environment with a long-lived database
+predating the switch: a `--tags update-databases` migration run against it
+succeeds, while a full `setup-databases` pass still stops on the mismatch.
+`grafana.yml` is the exception on the other side — its create task *is* tagged
+`update-databases`, and `grafana_db_name` is absent from
+`postgresql_init_managed_databases`, so it is neither checked nor deferred.
 
 The check runs once per database server rather than once overall. Keycloak's
 database is created against `keycloak_db_login_host`, which need not be

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,9 @@
 # Wiki Update Log
 
+## 2026-08-04
+
+* **Update**: [PostgreSQL](/infrastructure/postgresql.md) — the locale pre-flight is scoped to runs that create databases again. It had been given `apply: tags: update-databases` on the reading that a dynamic include needs it for its children to run under `--tags`, which is true in general but wrong here: every `postgresql_db` task the check guards is untagged and so is filtered out of a `--tags update-databases` run anyway. The result was a migrations-only pass against production aborting on a `keycloak` database created before the switch to ICU — over a reconciliation no task in scope was going to attempt. The check now carries no tags of its own and inherits the play's. Also recorded that `grafana.yml` is the exception on the other side: its create task is tagged `update-databases` while `grafana_db_name` is absent from `postgresql_init_managed_databases`, so it is neither checked nor deferred.
+
 ## 2026-08-03
 
 * **Update**: [vice-operator](/services/vice-operator.md) — `vice_operator_ca_bundle_configmap` now records which images can honour it. Merging `main` took the app-exposer and vice-operator build descriptors back to the `v2026.08.04` release, which predates the CA-bundle merge (app-exposer PR #164), so the flag the role renders does not exist in the image it pins: the operator exits at startup on an unknown flag and crash-loops. Nothing here is wrong for QA or production, where `de_ca_bundle_configmap` is empty and the flag is never rendered, but a deployment with a private CA sets it and gets a failure whose message names neither the release nor the variable. The page previously described the flag as unconditionally available.


### PR DESCRIPTION
A --tags update-databases run against production aborted on the keycloak database, which was created before the switch to locale_provider: icu. The pre-flight is right that postgresql_db cannot reconcile that — db_update in the collection hard-fails on a locale_provider mismatch — but nothing in that run was going to try. Every postgresql_db task in the role is untagged and so is filtered out of an update-databases run; only the checkouts, extension installs, migrations and seed queries survive it.

b7be3f3 gave the check apply: tags: update-databases, reading it as another instance of the trap that same commit fixed elsewhere: a dynamic include's tags decide only whether the file is included, so children need apply: to run under --tags. That generalization does not hold here, because the check is not something you want running under that tag at all. The result was a guard that fired precisely when the thing it guards was inert, and whose message told an operator to drop a production database to get migrations to run.

The check now carries no tags of its own and inherits the play's setup-databases and databases, which is what gates the creation tasks. A full pass still stops on a mismatch; a migrations-only pass no longer does.

Two things this deliberately does not address. A full setup-databases run against production will still fail on keycloak, and legitimately so — leaving a long-lived non-ICU database reconcilable is a separate change, since it means omitting the locale arguments for databases that already exist. grafana.yml is the exception on the other side: its create task is tagged update-databases while grafana_db_name is absent from postgresql_init_managed_databases, so it is neither checked nor deferred.