### PR TITLE
Record why vice-operator has to stay at one replica

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,14 @@
 # Wiki Update Log
 
+## 2026-08-11
+
+- Recorded in [vice-operator](/services/vice-operator.md) why
+  `vice_operator_replicas` has to stay at 1: the operator's save-and-exit
+  deduplication is an in-memory map, and duplicate requests arrive through its
+  Service, so a second replica can delete an analysis's resources while the
+  first is still uploading its outputs. Names what app-exposer would need (a
+  cluster-wide claim in its `operator` package) before the count can be raised.
+
 ## 2026-08-10
 
 - Removed `services/email-requests.md`: the email-requests service has been

--- a/wiki/services/vice-operator.md
+++ b/wiki/services/vice-operator.md
@@ -4,7 +4,7 @@ title: vice-operator
 description: Operator that runs VICE analyses in a dedicated namespace, built from the app-exposer repo and deployed with its own RBAC instead of skaffold.
 resource: /ansible/roles/services/vice-operator
 tags: [vice, operator, app-exposer, rbac, gateway, gpu]
-timestamp: 2026-08-03T00:00:00Z
+timestamp: 2026-08-11T00:00:00Z
 ---
 
 The vice-operator manages VICE analyses inside the `vice_ns` namespace: its
@@ -36,6 +36,31 @@ vars, plus `image_cache_mode` (`daemonset`, `cron`, or `manual-mirror` — the
 latter mounts `files/repos.json` as a ConfigMap; see
 [VICE Image Cache](/playbooks/vice-image-cache.md)). Default
 `vice_operator_replicas` is 1.
+
+## Why replicas stays at 1
+
+`vice_operator_replicas: 1` is a correctness requirement today, not a capacity
+choice. Save-and-exit uploads an analysis's outputs to iRODS and then deletes
+its Kubernetes resources, and duplicate requests for the same analysis are
+routine — app-exposer's expiration worker re-sends one on every sweep, from
+every app-exposer replica, until the analysis leaves the cluster. The operator
+drops the duplicates using an in-memory map of the analyses whose save-and-exit
+is already running.
+
+That map is per process, while the duplicates arrive over HTTP through the
+operator's Service. With two replicas, the second request lands on a replica
+whose map is empty, so it starts its own run and deletes the analysis's
+Deployment — including the file-transfer sidecar — while the first replica is
+still streaming files to iRODS. The user loses part or all of their outputs,
+silently.
+
+Raising the count needs a cluster-wide claim in app-exposer's `operator`
+package first: a coordination Lease, or a marker written on the analysis's own
+Deployment, in place of the in-memory map. Until that lands, treat any value
+above 1 as a data-loss risk rather than as scaling. Note that this bounds only
+the operator; app-exposer itself runs multiple replicas safely, because
+everything of its own that must happen once per analysis claims a
+`notif_statuses` row with `FOR UPDATE SKIP LOCKED`.
 
 `vice_operator_ca_bundle_configmap` does double duty. It mounts the named
 ConfigMap into the operator itself, so OIDC discovery against a Keycloak
@@ -107,3 +132,4 @@ See [Building and Deploying Services](/playbooks/build-and-deploy.md) and
 4. `ansible/roles/services/vice-operator/templates/vice_operator.yml.j2` — secret, optional repos ConfigMap, and the flag-driven Deployment.
 5. `ansible/roles/services/vice-operator/files/repos.json` — image mirror list for `manual-mirror` cache mode.
 6. `ansible/roles/common/defaults/main.yml` — `vice_operator_ca_bundle_configmap` and the shared `de_ca_bundle_*` settings it defaults from.
+7. [cyverse-de/app-exposer `operator/handlers.go`](https://github.com/cyverse-de/app-exposer/blob/main/operator/handlers.go) — the in-process `saveAndExitInFlight` map behind the single-replica requirement.


### PR DESCRIPTION
Wiki-only change, split out of the code review on [app-exposer #165](https://github.com/cyverse-de/app-exposer/pull/165).

The review found that vice-operator's save-and-exit deduplication (`saveAndExitInFlight`) is an in-memory map, while the duplicate requests it absorbs arrive over HTTP through the operator's Service — app-exposer's expiration worker re-sends a save-and-exit on every sweep, from every app-exposer replica. With more than one operator replica, the second request lands on a replica whose map is empty, and its cleanup deletes the analysis's Deployment (and the file-transfer sidecar) while the first replica is still streaming outputs to iRODS.

Nothing is being changed in the operator: it is a pre-existing constraint, `vice_operator_replicas` already defaults to 1, and there are no plans to scale the operators yet. This just records the constraint where replica counts are actually set, so a future scale-up doesn't find out the hard way, and names what app-exposer would need first (a cluster-wide claim — a Lease, or a marker on the analysis's Deployment).

`okf index` and `okf check` are clean (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)