### PR TITLE
Add a playbook for moving the notifications database into de

### DIFF
--- a/ansible/notifications_db_merge.yml
+++ b/ansible/notifications_db_merge.yml
@@ -1,0 +1,15 @@
+---
+# Moves the contents of the standalone notifications database into the DE
+# database. The schema is created by de-database migrations 000055 and 000056;
+# this playbook moves the rows.
+#
+# PRECONDITION: the notifications service must already be qualifying usernames
+# (appending uid_domain) before this runs. The standalone database stores bare
+# usernames and public.users stores qualified ones; a service still writing
+# bare usernames will insert them into the shared users table after the move.
+- name: Move the notifications database into the DE database
+  hosts: k8s_controllers[0]
+  connection: local
+  gather_facts: false
+  roles:
+    - role: notifications_db_merge

--- a/ansible/notifications_db_merge.yml
+++ b/ansible/notifications_db_merge.yml
@@ -3,10 +3,24 @@
 # database. The schema is created by de-database migrations 000055 and 000056;
 # this playbook moves the rows.
 #
-# PRECONDITION: the notifications service must already be qualifying usernames
-# (appending uid_domain) before this runs. The standalone database stores bare
-# usernames and public.users stores qualified ones; a service still writing
-# bare usernames will insert them into the shared users table after the move.
+# ORDERING: run this while the service is still pointed at the standalone
+# database, then repoint it. The username-qualification change and the
+# repointing must ship in the SAME deploy:
+#
+#   1. apply de-database migrations 000055 and 000056
+#   2. run this playbook -- the service keeps serving from the standalone
+#      database, which is left untouched
+#   3. deploy notifications with username qualification AND
+#      notifications.db.uri pointed at the DE database, together
+#   4. run this playbook again to sweep up anything recorded between 2 and 3;
+#      it is idempotent, so only the gap rows are added
+#
+# Qualification cannot ship earlier than the repoint: against the standalone
+# database, whose users rows are bare, a qualifying service looks up a username
+# that isn't there, creates a second row, and every listing joins through it --
+# users' existing notifications vanish from their lists. It cannot ship later
+# either, because a service writing bare usernames into the DE database inserts
+# them into the users table the rest of the DE keys off.
 - name: Move the notifications database into the DE database
   hosts: k8s_controllers[0]
   connection: local

--- a/ansible/roles/notifications_db_merge/defaults/main.yml
+++ b/ansible/roles/notifications_db_merge/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Working file for the dump taken from the standalone notifications database.
+notifications_db_merge_dump_file: "./{{ notifications_db_name }}_merge_dump.sql"
+
+# Schema the dump is loaded into inside the DE database. Dropped on success
+# unless notifications_db_merge_keep_staging is true.
+notifications_db_merge_staging_schema: notifications_staging
+
+# Leave the staging schema in place after a successful load, for inspection.
+notifications_db_merge_keep_staging: false
+
+# Discard notification users whose names match this pattern instead of creating
+# them. These are iplant-groups subject IDs that Terrain sends as the user for
+# team notifications; they are not people.
+notifications_db_merge_junk_user_pattern: "@grouper-%"

--- a/ansible/roles/notifications_db_merge/files/staging_schema.sql
+++ b/ansible/roles/notifications_db_merge/files/staging_schema.sql
@@ -1,0 +1,46 @@
+-- Staging copy of the standalone notifications database, created inside the DE
+-- database so the load can join against public.users. Deliberately hand-written
+-- rather than restored from the pg_dump: the dump fully qualifies every object
+-- as "public", and rewriting that to another schema means editing a file that
+-- also contains the jsonb payloads. The rows arrive by \copy instead.
+--
+-- schema_migrations is not staged; the standalone database's migration history
+-- does not carry over.
+--
+-- Expects -v staging=<schema name>. The caller is responsible for refusing to
+-- pass "public" here, since this drops the schema it is given.
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS :"staging" CASCADE;
+CREATE SCHEMA :"staging";
+
+SET search_path = :"staging";
+
+CREATE TABLE users (
+    id uuid NOT NULL PRIMARY KEY,
+    username varchar(512) NOT NULL UNIQUE
+);
+
+CREATE TABLE notification_types (
+    id uuid NOT NULL PRIMARY KEY,
+    name varchar(32) NOT NULL UNIQUE
+);
+
+CREATE TABLE notifications (
+    id uuid NOT NULL PRIMARY KEY,
+    notification_type_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    subject text NOT NULL,
+    seen boolean NOT NULL,
+    deleted boolean NOT NULL,
+    time_created timestamp with time zone NOT NULL,
+    incoming_json jsonb NOT NULL,
+    outgoing_json jsonb,
+    routing_key varchar(64)
+);
+
+-- Supports the user_id join in transform.sql; the table arrives with 800k+ rows.
+CREATE INDEX notifications_staging_user_id_index ON notifications (user_id);
+
+COMMIT;

--- a/ansible/roles/notifications_db_merge/files/transform.sql
+++ b/ansible/roles/notifications_db_merge/files/transform.sql
@@ -15,15 +15,36 @@ BEGIN;
 SET search_path = public, pg_catalog;
 
 --
+-- Qualify each staged username the same way the DE does. This truncates at the
+-- first '@' before appending rather than appending outright, matching
+-- apps.user/append-username-suffix -- the rule every DE service resolves
+-- usernames by:
+--
+--     (str (string/replace username #"@.*$" "") "@" (uid-domain))
+--
+-- So "stephen.wright@utoronto.ca" resolves to
+-- "stephen.wright@iplantcollaborative.org", which is the account the DE will
+-- use for them, and not a third spelling that exists nowhere else.
+--
+-- Junk subject IDs are excluded here; their notifications are dropped below.
+--
+CREATE TEMPORARY TABLE staged_user ON COMMIT DROP AS
+SELECT su.id,
+       su.username,
+       regexp_replace(su.username, '@.*$', '') || '@'  || :'uid_domain' AS de_username,
+       regexp_replace(su.username, '@.*$', '') || '@@' || :'uid_domain' AS de_username_malformed
+FROM :"staging".users su
+WHERE su.username NOT LIKE :'junk_pattern';
+
+CREATE UNIQUE INDEX ON staged_user (id);
+
+--
 -- Create DE users for staged accounts that have never been seen by the rest of
 -- the DE. These are real people who received a notification without ever
--- launching an analysis. Junk subject IDs are excluded here and their
--- notifications are dropped below.
+-- launching an analysis.
 --
 INSERT INTO users (username)
-SELECT su.username || '@' || :'uid_domain'
-FROM :"staging".users su
-WHERE su.username NOT LIKE :'junk_pattern'
+SELECT DISTINCT de_username FROM staged_user
 ON CONFLICT (username) DO NOTHING;
 
 --
@@ -35,16 +56,12 @@ ON CONFLICT (username) DO NOTHING;
 -- deterministically even where both spellings exist.
 --
 CREATE TEMPORARY TABLE user_map ON COMMIT DROP AS
-SELECT DISTINCT ON (su.id)
-       su.id AS staged_id,
+SELECT DISTINCT ON (sc.id)
+       sc.id AS staged_id,
        u.id  AS de_id
-FROM :"staging".users su
-JOIN users u ON u.username IN (
-        su.username || '@' || :'uid_domain',
-        su.username || '@@' || :'uid_domain'
-     )
-WHERE su.username NOT LIKE :'junk_pattern'
-ORDER BY su.id, (u.username LIKE '%@@%');
+FROM staged_user sc
+JOIN users u ON u.username IN (sc.de_username, sc.de_username_malformed)
+ORDER BY sc.id, (u.username LIKE '%@@%');
 
 CREATE UNIQUE INDEX ON user_map (staged_id);
 

--- a/ansible/roles/notifications_db_merge/files/transform.sql
+++ b/ansible/roles/notifications_db_merge/files/transform.sql
@@ -1,0 +1,80 @@
+-- Moves the staged notification rows into public.notifications, resolving the
+-- two identifiers that differ between the databases:
+--
+--   users  the standalone database stores bare usernames ("jdoe"); public.users
+--          stores them qualified ("jdoe@iplantcollaborative.org"). No user has
+--          the same id in both databases, so every user_id is remapped.
+--   types  the standalone database keys notifications to its own
+--          notification_types rows; migration 000055 seeded public by name.
+--
+-- Expects -v staging=<schema name> -v uid_domain=<domain> -v junk_pattern=<like pattern>.
+-- Idempotent: re-running loads only notifications not already present.
+
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+--
+-- Create DE users for staged accounts that have never been seen by the rest of
+-- the DE. These are real people who received a notification without ever
+-- launching an analysis. Junk subject IDs are excluded here and their
+-- notifications are dropped below.
+--
+INSERT INTO users (username)
+SELECT su.username || '@' || :'uid_domain'
+FROM :"staging".users su
+WHERE su.username NOT LIKE :'junk_pattern'
+ON CONFLICT (username) DO NOTHING;
+
+--
+-- Resolve every staged user to a DE user.
+--
+-- The single-@ preference matters: 128k of public.users' rows are
+-- "name@@domain" duplicates of a "name@domain" row, and it is the single-@ row
+-- that the rest of the DE references. DISTINCT ON with this ordering picks it
+-- deterministically even where both spellings exist.
+--
+CREATE TEMPORARY TABLE user_map ON COMMIT DROP AS
+SELECT DISTINCT ON (su.id)
+       su.id AS staged_id,
+       u.id  AS de_id
+FROM :"staging".users su
+JOIN users u ON u.username IN (
+        su.username || '@' || :'uid_domain',
+        su.username || '@@' || :'uid_domain'
+     )
+WHERE su.username NOT LIKE :'junk_pattern'
+ORDER BY su.id, (u.username LIKE '%@@%');
+
+CREATE UNIQUE INDEX ON user_map (staged_id);
+
+--
+-- Resolve staged notification types by name. Migration 000055 seeded all nine
+-- names, so an unmatched row means the standalone database grew a tenth after
+-- that migration was written; the count check below will catch it.
+--
+CREATE TEMPORARY TABLE type_map ON COMMIT DROP AS
+SELECT st.id AS staged_id,
+       nt.id AS de_id
+FROM :"staging".notification_types st
+JOIN notification_types nt ON nt.name = st.name;
+
+CREATE UNIQUE INDEX ON type_map (staged_id);
+
+--
+-- Notification ids are preserved. They are distinct from every id already in
+-- the DE database, and clients hold them: outgoing_json embeds the id as
+-- message.id and the update endpoints address notifications by it.
+--
+INSERT INTO notifications (
+    id, notification_type_id, user_id, subject, seen, deleted,
+    time_created, incoming_json, outgoing_json, routing_key
+)
+SELECT sn.id, tm.de_id, um.de_id, sn.subject, sn.seen, sn.deleted,
+       sn.time_created, sn.incoming_json, sn.outgoing_json, sn.routing_key
+FROM :"staging".notifications sn
+JOIN user_map um ON um.staged_id = sn.user_id
+JOIN type_map tm ON tm.staged_id = sn.notification_type_id
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/ansible/roles/notifications_db_merge/files/verify.sql
+++ b/ansible/roles/notifications_db_merge/files/verify.sql
@@ -6,17 +6,22 @@
 
 SET search_path = public, pg_catalog;
 
-WITH resolved AS (
-    SELECT su.id
+WITH staged_user AS (
+    -- Same qualification rule as transform.sql: truncate at the first '@'
+    -- before appending, matching apps.user/append-username-suffix.
+    SELECT su.id,
+           regexp_replace(su.username, '@.*$', '') || '@'  || :'uid_domain' AS de_username,
+           regexp_replace(su.username, '@.*$', '') || '@@' || :'uid_domain' AS de_username_malformed
     FROM :"staging".users su
     WHERE su.username NOT LIKE :'junk_pattern'
-      AND EXISTS (
-          SELECT 1 FROM users u
-          WHERE u.username IN (
-              su.username || '@' || :'uid_domain',
-              su.username || '@@' || :'uid_domain'
-          )
-      )
+),
+resolved AS (
+    SELECT sc.id
+    FROM staged_user sc
+    WHERE EXISTS (
+        SELECT 1 FROM users u
+        WHERE u.username IN (sc.de_username, sc.de_username_malformed)
+    )
 )
 SELECT
     (SELECT count(*) FROM :"staging".notifications) AS staged_notifications,
@@ -31,12 +36,21 @@ SELECT
 
     -- Should be zero: transform.sql creates a DE user for every non-junk
     -- staged account before mapping.
-    (SELECT count(*) FROM :"staging".users su
-      WHERE su.username NOT LIKE :'junk_pattern'
-        AND su.id NOT IN (SELECT id FROM resolved)) AS unmapped_users,
+    (SELECT count(*) FROM staged_user sc
+      WHERE sc.id NOT IN (SELECT id FROM resolved)) AS unmapped_users,
     (SELECT count(*) FROM :"staging".notification_types st
       WHERE NOT EXISTS (SELECT 1 FROM notification_types nt
                          WHERE nt.name = st.name))  AS unmapped_types,
+
+    -- Two staged accounts qualifying to one DE username -- "jdoe" and
+    -- "jdoe@elsewhere.edu" both resolve to "jdoe@<uid_domain>". Neither
+    -- environment has any today. If one appears, their notification histories
+    -- would silently merge under a single DE user, so this fails the load
+    -- rather than guessing that they are the same person.
+    (SELECT count(*) FROM (
+        SELECT de_username FROM staged_user
+        GROUP BY de_username HAVING count(*) > 1
+     ) c)                                           AS colliding_users,
 
     -- What should have landed, and what did.
     (SELECT count(*) FROM :"staging".notifications sn

--- a/ansible/roles/notifications_db_merge/files/verify.sql
+++ b/ansible/roles/notifications_db_merge/files/verify.sql
@@ -1,0 +1,44 @@
+-- Reconciles the load against the staged rows. Returns one row; the playbook
+-- asserts on it rather than raising here, so a failure prints every count
+-- instead of only the first one that tripped.
+--
+-- Expects -v staging=<schema name> -v uid_domain=<domain> -v junk_pattern=<like pattern>.
+
+SET search_path = public, pg_catalog;
+
+WITH resolved AS (
+    SELECT su.id
+    FROM :"staging".users su
+    WHERE su.username NOT LIKE :'junk_pattern'
+      AND EXISTS (
+          SELECT 1 FROM users u
+          WHERE u.username IN (
+              su.username || '@' || :'uid_domain',
+              su.username || '@@' || :'uid_domain'
+          )
+      )
+)
+SELECT
+    (SELECT count(*) FROM :"staging".notifications) AS staged_notifications,
+    (SELECT count(*) FROM :"staging".users)         AS staged_users,
+
+    -- Deliberately discarded: iplant-groups subject IDs, not people.
+    (SELECT count(*) FROM :"staging".users
+      WHERE username LIKE :'junk_pattern')          AS junk_users,
+    (SELECT count(*) FROM :"staging".notifications sn
+      JOIN :"staging".users su ON su.id = sn.user_id
+     WHERE su.username LIKE :'junk_pattern')        AS junk_notifications,
+
+    -- Should be zero: transform.sql creates a DE user for every non-junk
+    -- staged account before mapping.
+    (SELECT count(*) FROM :"staging".users su
+      WHERE su.username NOT LIKE :'junk_pattern'
+        AND su.id NOT IN (SELECT id FROM resolved)) AS unmapped_users,
+    (SELECT count(*) FROM :"staging".notification_types st
+      WHERE NOT EXISTS (SELECT 1 FROM notification_types nt
+                         WHERE nt.name = st.name))  AS unmapped_types,
+
+    -- What should have landed, and what did.
+    (SELECT count(*) FROM :"staging".notifications sn
+      WHERE sn.user_id IN (SELECT id FROM resolved)) AS expected_notifications,
+    (SELECT count(*) FROM notifications)             AS loaded_notifications;

--- a/ansible/roles/notifications_db_merge/meta/main.yml
+++ b/ansible/roles/notifications_db_merge/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/ansible/roles/notifications_db_merge/tasks/cleanup.yml
+++ b/ansible/roles/notifications_db_merge/tasks/cleanup.yml
@@ -1,0 +1,24 @@
+---
+- name: Drop the staging schema
+  delegate_to: localhost
+  become: false
+  block:
+    - name: Remove the staging schema from the de database
+      community.postgresql.postgresql_schema:
+        name: "{{ notifications_db_merge_staging_schema }}"
+        state: absent
+        cascade_drop: true
+        login_db: "{{ de_db_name }}"
+        login_host: "{{ db_login_host }}"
+        login_port: "{{ pg_listen_port }}"
+        login_user: "{{ pg_login_user }}"
+        login_password: "{{ pg_login_password }}"
+      when: not notifications_db_merge_keep_staging
+
+    - name: Note where the rollback dump was left
+      ansible.builtin.debug:
+        msg: >
+          The standalone notifications database is untouched and a dump of it
+          is at {{ notifications_db_merge_dump_file }}. Neither is removed by
+          this playbook; retire them once the service has been cut over and
+          verified.

--- a/ansible/roles/notifications_db_merge/tasks/dump.yml
+++ b/ansible/roles/notifications_db_merge/tasks/dump.yml
@@ -1,0 +1,37 @@
+---
+- name: Dump the notifications database
+  delegate_to: localhost
+  become: false
+  block:
+    - name: Check that de-database migration 000056 has been applied
+      community.postgresql.postgresql_query:
+        login_host: "{{ db_login_host }}"
+        login_port: "{{ pg_listen_port }}"
+        login_user: "{{ pg_login_user }}"
+        login_password: "{{ pg_login_password }}"
+        login_db: "{{ de_db_name }}"
+        query: SELECT to_regclass('public.notifications') IS NOT NULL AS ready
+      register: notifications_db_merge_schema_check
+      changed_when: false
+
+    - name: Fail if the target table is missing
+      ansible.builtin.fail:
+        msg: >
+          public.notifications does not exist in the {{ de_db_name }} database.
+          Run the de-database migrations (000055 and 000056) before this playbook.
+      when: not notifications_db_merge_schema_check.query_result[0].ready
+
+    - name: Dump the notifications database to a file
+      environment:
+        PGPASSWORD: "{{ dbms_connection_pass }}"
+      ansible.builtin.shell:
+        cmd: >
+          pg_dump {{ notifications_db_name }}
+          --host={{ db_login_host }}
+          --port={{ pg_listen_port }}
+          --username={{ dbms_connection_user }}
+          --file {{ notifications_db_merge_dump_file }}
+          --no-owner
+          --no-privileges
+          -n public
+        creates: "{{ notifications_db_merge_dump_file }}"

--- a/ansible/roles/notifications_db_merge/tasks/load.yml
+++ b/ansible/roles/notifications_db_merge/tasks/load.yml
@@ -1,0 +1,22 @@
+---
+- name: Load the staged rows into public.notifications
+  delegate_to: localhost
+  become: false
+  block:
+    - name: Transform the staged rows into public.notifications
+      environment:
+        PGPASSWORD: "{{ dbms_connection_pass }}"
+      ansible.builtin.shell:
+        cmd: >
+          psql
+          --host={{ db_login_host }}
+          --port={{ pg_listen_port }}
+          --username={{ dbms_connection_user }}
+          --dbname={{ de_db_name }}
+          --set=ON_ERROR_STOP=1
+          --set=staging={{ notifications_db_merge_staging_schema }}
+          --set=uid_domain={{ uid_domain }}
+          --set=junk_pattern={{ notifications_db_merge_junk_user_pattern }}
+          --file=-
+        stdin: "{{ lookup('ansible.builtin.file', 'transform.sql') }}"
+      changed_when: true

--- a/ansible/roles/notifications_db_merge/tasks/main.yml
+++ b/ansible/roles/notifications_db_merge/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Dump the standalone notifications database
+  ansible.builtin.import_tasks:
+    file: dump.yml
+  tags:
+    - dump
+
+- name: Stage the notification rows inside the de database
+  ansible.builtin.import_tasks:
+    file: stage.yml
+  tags:
+    - stage
+
+- name: Load the staged rows into public.notifications
+  ansible.builtin.import_tasks:
+    file: load.yml
+  tags:
+    - load
+
+- name: Reconcile the load
+  ansible.builtin.import_tasks:
+    file: verify.yml
+  tags:
+    - verify
+
+- name: Drop the staging schema
+  ansible.builtin.import_tasks:
+    file: cleanup.yml
+  tags:
+    - cleanup

--- a/ansible/roles/notifications_db_merge/tasks/stage.yml
+++ b/ansible/roles/notifications_db_merge/tasks/stage.yml
@@ -1,0 +1,67 @@
+---
+- name: Stage the notification rows inside the de database
+  delegate_to: localhost
+  become: false
+  block:
+    - name: Refuse to stage into a schema we should not drop
+      ansible.builtin.assert:
+        that:
+          - notifications_db_merge_staging_schema is match('^[a-z_][a-z0-9_]*$')
+          - notifications_db_merge_staging_schema not in ['public', 'metadata', 'permissions']
+        fail_msg: >
+          notifications_db_merge_staging_schema must be a plain lowercase identifier
+          and must not name an existing DE schema; the staging step drops it.
+
+    - name: Create the staging schema in the de database
+      environment:
+        PGPASSWORD: "{{ dbms_connection_pass }}"
+      ansible.builtin.shell:
+        cmd: >
+          psql
+          --host={{ db_login_host }}
+          --port={{ pg_listen_port }}
+          --username={{ dbms_connection_user }}
+          --dbname={{ de_db_name }}
+          --set=ON_ERROR_STOP=1
+          --set=staging={{ notifications_db_merge_staging_schema }}
+          --file=-
+        stdin: "{{ lookup('ansible.builtin.file', 'staging_schema.sql') }}"
+      changed_when: true
+
+    # Streamed rather than restored from the dump: pg_dump qualifies every
+    # object as "public", and rewriting that to another schema means editing a
+    # file that also contains the jsonb payloads.
+    - name: Stream the notification rows into the staging schema
+      environment:
+        PGPASSWORD: "{{ dbms_connection_pass }}"
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          psql --host={{ db_login_host }} --port={{ pg_listen_port }} \
+               --username={{ dbms_connection_user }} --dbname={{ notifications_db_name }} \
+               --set=ON_ERROR_STOP=1 \
+               -c "\copy (SELECT * FROM {{ item }}) TO STDOUT WITH (FORMAT csv)" \
+          | psql --host={{ db_login_host }} --port={{ pg_listen_port }} \
+                 --username={{ dbms_connection_user }} --dbname={{ de_db_name }} \
+                 --set=ON_ERROR_STOP=1 \
+                 -c "\copy {{ notifications_db_merge_staging_schema }}.{{ item }} FROM STDIN WITH (FORMAT csv)"
+        executable: /bin/bash
+      changed_when: true
+      loop:
+        - users
+        - notification_types
+        - notifications
+
+    - name: Analyze the staged tables
+      community.postgresql.postgresql_query:
+        login_host: "{{ db_login_host }}"
+        login_port: "{{ pg_listen_port }}"
+        login_user: "{{ pg_login_user }}"
+        login_password: "{{ pg_login_password }}"
+        login_db: "{{ de_db_name }}"
+        query: "ANALYZE {{ notifications_db_merge_staging_schema }}.{{ item }}"
+      changed_when: false
+      loop:
+        - users
+        - notification_types
+        - notifications

--- a/ansible/roles/notifications_db_merge/tasks/verify.yml
+++ b/ansible/roles/notifications_db_merge/tasks/verify.yml
@@ -33,9 +33,10 @@
         notifications_db_merge_counts: >-
           {{ dict(['staged_notifications', 'staged_users', 'junk_users',
                    'junk_notifications', 'unmapped_users', 'unmapped_types',
-                   'expected_notifications', 'loaded_notifications']
+                   'colliding_users', 'expected_notifications',
+                   'loaded_notifications']
                   | zip(notifications_db_merge_reconciliation.stdout_lines
-                        | select('match', '^([0-9]+,){7}[0-9]+$')
+                        | select('match', '^([0-9]+,){8}[0-9]+$')
                         | first | split(',') | map('int'))) }}
 
     - name: Report the reconciliation
@@ -47,12 +48,15 @@
         that:
           - notifications_db_merge_counts.unmapped_users == 0
           - notifications_db_merge_counts.unmapped_types == 0
+          - notifications_db_merge_counts.colliding_users == 0
           - notifications_db_merge_counts.loaded_notifications == notifications_db_merge_counts.expected_notifications
         fail_msg: >
           The notifications load did not reconcile: {{ notifications_db_merge_counts }}.
           unmapped_users or unmapped_types above zero means a staged account or
-          type had no DE counterpart; a loaded/expected mismatch means rows were
-          dropped or public.notifications was not empty before the load.
+          type had no DE counterpart; colliding_users means two notification
+          accounts qualify to one DE username and their histories would merge;
+          a loaded/expected mismatch means rows were dropped or
+          public.notifications was not empty before the load.
         success_msg: >
           Loaded {{ notifications_db_merge_counts.loaded_notifications }} of
           {{ notifications_db_merge_counts.staged_notifications }} staged notifications;

--- a/ansible/roles/notifications_db_merge/tasks/verify.yml
+++ b/ansible/roles/notifications_db_merge/tasks/verify.yml
@@ -1,0 +1,60 @@
+---
+- name: Reconcile the load against the staged rows
+  delegate_to: localhost
+  become: false
+  block:
+    - name: Query the reconciliation counts
+      environment:
+        PGPASSWORD: "{{ dbms_connection_pass }}"
+      ansible.builtin.shell:
+        cmd: >
+          psql
+          --host={{ db_login_host }}
+          --port={{ pg_listen_port }}
+          --username={{ dbms_connection_user }}
+          --dbname={{ de_db_name }}
+          --set=ON_ERROR_STOP=1
+          --set=staging={{ notifications_db_merge_staging_schema }}
+          --set=uid_domain={{ uid_domain }}
+          --set=junk_pattern={{ notifications_db_merge_junk_user_pattern }}
+          --quiet
+          --tuples-only
+          --no-align
+          --field-separator=,
+          --file=-
+        stdin: "{{ lookup('ansible.builtin.file', 'verify.sql') }}"
+      register: notifications_db_merge_reconciliation
+      changed_when: false
+
+    # Selected by shape rather than position: psql can emit a notice after the
+    # result, so the counts are not reliably the last line.
+    - name: Parse the reconciliation counts
+      ansible.builtin.set_fact:
+        notifications_db_merge_counts: >-
+          {{ dict(['staged_notifications', 'staged_users', 'junk_users',
+                   'junk_notifications', 'unmapped_users', 'unmapped_types',
+                   'expected_notifications', 'loaded_notifications']
+                  | zip(notifications_db_merge_reconciliation.stdout_lines
+                        | select('match', '^([0-9]+,){7}[0-9]+$')
+                        | first | split(',') | map('int'))) }}
+
+    - name: Report the reconciliation
+      ansible.builtin.debug:
+        var: notifications_db_merge_counts
+
+    - name: Fail if the load did not reconcile
+      ansible.builtin.assert:
+        that:
+          - notifications_db_merge_counts.unmapped_users == 0
+          - notifications_db_merge_counts.unmapped_types == 0
+          - notifications_db_merge_counts.loaded_notifications == notifications_db_merge_counts.expected_notifications
+        fail_msg: >
+          The notifications load did not reconcile: {{ notifications_db_merge_counts }}.
+          unmapped_users or unmapped_types above zero means a staged account or
+          type had no DE counterpart; a loaded/expected mismatch means rows were
+          dropped or public.notifications was not empty before the load.
+        success_msg: >
+          Loaded {{ notifications_db_merge_counts.loaded_notifications }} of
+          {{ notifications_db_merge_counts.staged_notifications }} staged notifications;
+          discarded {{ notifications_db_merge_counts.junk_notifications }} belonging to
+          {{ notifications_db_merge_counts.junk_users }} non-person subject IDs.

--- a/ansible/roles/services/notifications/templates/jobservices.yml.j2
+++ b/ansible/roles/services/notifications/templates/jobservices.yml.j2
@@ -90,6 +90,9 @@ notification_agent:
 notifications:
   db:
     uri: "postgresql://{{ dbms_connection_user }}:{{ dbms_connection_pass | urlencode }}@{{ groups['dbms'][0] }}:{{ pg_listen_port }}/{{ notifications_db_name }}?sslmode=disable"
+  uid:
+    # Callers send bare usernames; the DE identifies users by the qualified form.
+    domain: "{{ uid_domain }}"
 
 path_list:
   file_identifier: "# application/vnd.de.multi-input-path-list+csv; version=1"

--- a/wiki/infrastructure/postgresql.md
+++ b/wiki/infrastructure/postgresql.md
@@ -4,7 +4,7 @@ title: PostgreSQL
 description: How PostgreSQL is installed and the DE databases are initialized by the install-postgres and setup-databases passes of kubernetes.yml, plus day-to-day operations such as backups, manual migrations, and diagnostics.
 resource: /docs/postgresql.md
 tags: [postgresql, database, kubernetes.yml]
-timestamp: 2026-08-04T12:00:00Z
+timestamp: 2026-08-14T00:00:00Z
 ---
 
 PostgreSQL is installed and initialized as part of the `kubernetes.yml`
@@ -170,7 +170,7 @@ typically reachable directly from operator workstations (or via VPN). Connect wi
 | Database        | Purpose                                                    |
 | --------        | -------                                                    |
 | `de`            | Main DE database: analyses, apps, tools, users, subscriptions |
-| `notifications` | Notification records                                       |
+| `notifications` | Notification records. Being folded into `de`; see [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md) |
 | `metadata`      | Metadata templates and AVUs                                |
 | `qms`           | Quota/subscription management (if QMS enabled); migrations come from the `subscriptions` repo |
 | `keycloak`      | Keycloak user and realm data                               |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -23,7 +23,8 @@
   dedicated database is being retired, and documented the new required
   `notifications.uid.domain` setting the service qualifies usernames with
   before any database lookup, along with the reason `outgoing_json` keeps the
-  bare username the caller sent.
+  bare username the caller sent and why the change ships in the same deploy as
+  the repoint rather than ahead of it.
 * **Update**: [PostgreSQL](/infrastructure/postgresql.md) — flagged the
   `notifications` database as being folded into `de` in the database table.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -5,15 +5,20 @@
 * **Add**: [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
   — covers `notifications_db_merge.yml`, which moves the standalone
   notifications database into `public.notifications` in the DE database.
-  Documents the two identifier remappings the move requires (users by
-  suffixed username, preferring the single-`@` row where the malformed
-  double-`@` duplicate also exists; notification types by name against the
-  lookup table that `de-database` migration `000055` puts in place of the old
-  enum), the staging schema and why the rows are streamed rather than restored
-  from the `pg_dump`, and the handling of notification accounts the DE has
-  never seen — real people are created, iplant-groups subject IDs are
-  discarded. The username-qualification change to the service is called out as
-  a precondition the playbook cannot itself check.
+  Documents the two identifier remappings the move requires: users by
+  qualified username, which truncates at the first `@` before appending
+  `uid_domain` the way `apps.user/append-username-suffix` does — so an account
+  already named as an address resolves to its real DE account rather than to a
+  `name@elsewhere.edu@iplantcollaborative.org` stray — and preferring the
+  single-`@` row where the malformed double-`@` duplicate also exists;
+  notification types by name against the lookup table that `de-database`
+  migration `000055` puts in place of the old enum. Also covers the staging
+  schema and why the rows are streamed rather than restored from the
+  `pg_dump`, the handling of notification accounts the DE has never seen (real
+  people are created, iplant-groups subject IDs are discarded), and the
+  collision check that fails the load rather than merging two people's
+  histories under one DE user. The username-qualification change to the
+  service is called out as a precondition the playbook cannot itself check.
 * **Update**: [notifications](/services/notifications.md) — noted that the
   dedicated database is being retired, with the service-side username
   qualification that has to land before the move.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -20,8 +20,10 @@
   histories under one DE user. The username-qualification change to the
   service is called out as a precondition the playbook cannot itself check.
 * **Update**: [notifications](/services/notifications.md) — noted that the
-  dedicated database is being retired, with the service-side username
-  qualification that has to land before the move.
+  dedicated database is being retired, and documented the new required
+  `notifications.uid.domain` setting the service qualifies usernames with
+  before any database lookup, along with the reason `outgoing_json` keeps the
+  bare username the caller sent.
 * **Update**: [PostgreSQL](/infrastructure/postgresql.md) — flagged the
   `notifications` database as being folded into `de` in the database table.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,25 @@
 # Wiki Update Log
 
+## 2026-08-14
+
+* **Add**: [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
+  — covers `notifications_db_merge.yml`, which moves the standalone
+  notifications database into `public.notifications` in the DE database.
+  Documents the two identifier remappings the move requires (users by
+  suffixed username, preferring the single-`@` row where the malformed
+  double-`@` duplicate also exists; notification types by name against the
+  lookup table that `de-database` migration `000055` puts in place of the old
+  enum), the staging schema and why the rows are streamed rather than restored
+  from the `pg_dump`, and the handling of notification accounts the DE has
+  never seen — real people are created, iplant-groups subject IDs are
+  discarded. The username-qualification change to the service is called out as
+  a precondition the playbook cannot itself check.
+* **Update**: [notifications](/services/notifications.md) — noted that the
+  dedicated database is being retired, with the service-side username
+  qualification that has to land before the move.
+* **Update**: [PostgreSQL](/infrastructure/postgresql.md) — flagged the
+  `notifications` database as being folded into `de` in the database table.
+
 ## 2026-08-12
 
 * **Remove**: `services/de-mailer.md` — de-mailer has been merged into

--- a/wiki/playbooks/index.md
+++ b/wiki/playbooks/index.md
@@ -14,6 +14,7 @@
 * [Longhorn Teardown](/playbooks/longhorn-teardown.md) - The all-or-nothing procedure for deleting a Longhorn install from a cluster, and how to recover if the default BackupTarget was deleted prematurely.
 * [Miscellaneous Utility Playbooks](/playbooks/misc-utility-playbooks.md) - A catalog of the small standalone playbooks - security mitigations, k3s-era cleanup, host surveys, database copies, config pushes, app imports, and GoCD kubeconfig transfer.
 * [Node OS Updates and Rolling Reboots](/playbooks/node-maintenance.md) - OS package updates with update_nodes.yml and drained, rolling reboots of cluster nodes with reboot_nodes.yml.
+* [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md) - How notifications_db_merge.yml moves the standalone notifications database into the DE database's public schema, remapping user and notification-type identifiers on the way.
 * [General Operations Runbook](/playbooks/ops-runbook.md) - Day-to-day DE cluster operations — health checks, restarts, scaling, rollbacks, config pushes, log access, and node maintenance.
 * [Portal Exim Mail Relay](/playbooks/portal-exim.md) - How portal-exim.yml deploys an exim4 SMTP relay into the portal namespace for outbound portal mail.
 * [VICE Image Caching](/playbooks/vice-image-cache.md) - The two mechanisms for pre-pulling VICE images onto worker nodes - the kube-fledged image_cache role and the legacy vice-cache Job playbook.

--- a/wiki/playbooks/notifications-db-merge.md
+++ b/wiki/playbooks/notifications-db-merge.md
@@ -41,9 +41,22 @@ of the database. It is the one step that has to be sequenced by hand.
 Both keys have to be rewritten, because neither survives the move:
 
 - **Users.** No account shares an id between the two databases, so every
-  `user_id` is remapped by username. Where both `name@domain` and the
-  malformed `name@@domain` spellings exist in `public.users`, the single-`@`
-  row wins — that is the row the rest of the DE references.
+  `user_id` is remapped by username, qualified the way every other DE service
+  qualifies one — `apps.user/append-username-suffix`, which **truncates at the
+  first `@` before appending** rather than appending outright:
+
+  ```clojure
+  (str (string/replace username #"@.*$" "") "@" (uid-domain))
+  ```
+
+  That distinction matters for the handful of notification accounts whose name
+  is already an address. `stephen.wright@utoronto.ca` resolves to
+  `stephen.wright@iplantcollaborative.org` — their real DE account — and not to
+  `stephen.wright@utoronto.ca@iplantcollaborative.org`, which also exists in
+  `public.users` but is a stray nothing else references.
+
+  Where both `name@domain` and the malformed `name@@domain` spellings exist,
+  the single-`@` row wins; that is the row the rest of the DE references.
 - **Notification types.** The standalone database keys notifications to its own
   `notification_types` rows. Migration `000055` replaced the DE's
   `notification_types` enum with a table seeded by name, so the mapping is by
@@ -70,7 +83,11 @@ Each is separately tagged (`dump`, `stage`, `load`, `verify`, `cleanup`).
    accounts the DE has never seen, resolves the two mappings into temporary
    tables, and inserts. It is idempotent; a second run inserts nothing.
 4. **Verify** — runs `files/verify.sql` and fails the play unless every staged
-   account and type resolved and the loaded count matches the expected count.
+   account and type resolved, no two staged accounts qualify to the same DE
+   username, and the loaded count matches the expected count. The collision
+   check is there because two accounts merging under one DE user would
+   otherwise reconcile perfectly while silently combining two people's
+   notification histories; neither environment has one today.
 5. **Cleanup** — drops the staging schema unless
    `notifications_db_merge_keep_staging` is set.
 

--- a/wiki/playbooks/notifications-db-merge.md
+++ b/wiki/playbooks/notifications-db-merge.md
@@ -1,0 +1,115 @@
+---
+type: Playbook
+title: Merging the Notifications Database into DE
+description: How notifications_db_merge.yml moves the standalone notifications database into the DE database's public schema, remapping user and notification-type identifiers on the way.
+resource: /ansible/notifications_db_merge.yml
+tags: [notifications, postgresql, migration, database, de-database]
+timestamp: 2026-08-14T00:00:00Z
+---
+
+The [notifications](/services/notifications.md) service has always kept its own
+database. Its rows are really satellites of the DE database — every analysis
+notification carries a `jobs.id` in its JSON payload — but the relationship is
+expressed as an opaque string across a database boundary, unenforceable and
+unjoinable. `notifications_db_merge.yml` closes that gap by moving the rows
+into `public.notifications` in the DE database.
+
+The schema is created by `de-database` migrations `000055` and `000056`; this
+playbook moves only the data. A migration cannot reach across databases, and
+neither `dblink` nor `postgres_fdw` is installed on the
+[PostgreSQL](/infrastructure/postgresql.md) DBMS.
+
+```bash
+ansible-playbook -i <inventory> notifications_db_merge.yml
+```
+
+## Precondition: the service must qualify usernames first
+
+**Run this only after the notifications service has been changed to append
+`uid_domain` to usernames.** The standalone database stores bare usernames
+(`jdoe`); `public.users` stores qualified ones (`jdoe@iplantcollaborative.org`).
+The service writes table names unqualified and normalizes nothing, and its user
+upsert is `INSERT INTO users (username) ... ON CONFLICT (username) DO UPDATE`.
+Pointed at the DE database while still writing bare usernames, it will insert
+them into the `users` table that apps, analyses, and requests all key off.
+
+The playbook cannot check this — it is a property of the running service, not
+of the database. It is the one step that has to be sequenced by hand.
+
+## What the two identifiers do
+
+Both keys have to be rewritten, because neither survives the move:
+
+- **Users.** No account shares an id between the two databases, so every
+  `user_id` is remapped by username. Where both `name@domain` and the
+  malformed `name@@domain` spellings exist in `public.users`, the single-`@`
+  row wins — that is the row the rest of the DE references.
+- **Notification types.** The standalone database keys notifications to its own
+  `notification_types` rows. Migration `000055` replaced the DE's
+  `notification_types` enum with a table seeded by name, so the mapping is by
+  name.
+
+Notification ids are preserved. Clients hold them: `outgoing_json` embeds the
+id as `message.id`, and the update endpoints address notifications by it.
+
+## The plays
+
+Each is separately tagged (`dump`, `stage`, `load`, `verify`, `cleanup`).
+
+1. **Dump** — refuses to start unless `public.notifications` exists, then
+   `pg_dump`s the standalone database to `notifications_db_merge_dump_file`.
+   The dump is the rollback artifact, not the load path; the playbook never
+   removes it.
+2. **Stage** — creates `notifications_db_merge_staging_schema` inside the DE
+   database from `files/staging_schema.sql` and streams the rows in with
+   `\copy ... TO STDOUT | \copy ... FROM STDIN`. The staging DDL is
+   hand-written rather than restored from the dump on purpose: `pg_dump`
+   qualifies every object as `public`, and rewriting that to another schema
+   means editing a file that also holds the jsonb payloads.
+3. **Load** — runs `files/transform.sql`, which creates DE users for staged
+   accounts the DE has never seen, resolves the two mappings into temporary
+   tables, and inserts. It is idempotent; a second run inserts nothing.
+4. **Verify** — runs `files/verify.sql` and fails the play unless every staged
+   account and type resolved and the loaded count matches the expected count.
+5. **Cleanup** — drops the staging schema unless
+   `notifications_db_merge_keep_staging` is set.
+
+## Accounts with no DE counterpart
+
+The notifications service creates a user row on demand for anyone it receives a
+notification about, so its user list is **not** a subset of `public.users`. Two
+kinds of stranger turn up:
+
+- **Real people** who were notified without ever launching an analysis. The
+  transform creates them in `public.users` with the suffix applied.
+- **iplant-groups subject IDs**, which terrain sends as the user for team
+  notifications. These match `notifications_db_merge_junk_user_pattern`
+  (`@grouper-%`), are not people, and are discarded along with their
+  notifications. The verify step reports how many went.
+
+## Settings
+
+All in `ansible/roles/notifications_db_merge/defaults/main.yml` except
+`uid_domain`, which comes from `ansible/roles/common/defaults/main.yml`.
+
+| Setting | Default | Purpose |
+| ------- | ------- | ------- |
+| `notifications_db_merge_dump_file` | `./notifications_merge_dump.sql` | Rollback dump location |
+| `notifications_db_merge_staging_schema` | `notifications_staging` | Schema the rows land in first; **dropped** by the staging step, so it must not name a real schema |
+| `notifications_db_merge_keep_staging` | `false` | Leave staging in place for inspection |
+| `notifications_db_merge_junk_user_pattern` | `@grouper-%` | Accounts discarded instead of created |
+| `uid_domain` | `iplantcollaborative.org` | Suffix joining bare usernames to `public.users` |
+
+## After the move
+
+The standalone database is left untouched and running. Retire it — along with
+the `notifications-db` migration job, the `db_copy_prod` notifications task,
+and the `notifications.db.uri` stanza that six service configs carry but never
+read — only once the service has been cut over and verified.
+
+# Citations
+
+[1] `ansible/notifications_db_merge.yml` — the playbook.
+[2] `ansible/roles/notifications_db_merge/` — role tasks, defaults, and SQL.
+[3] [notifications](/services/notifications.md) — the service that owns these rows.
+[4] [PostgreSQL](/infrastructure/postgresql.md) — the DBMS and its databases.

--- a/wiki/playbooks/notifications-db-merge.md
+++ b/wiki/playbooks/notifications-db-merge.md
@@ -23,18 +23,32 @@ neither `dblink` nor `postgres_fdw` is installed on the
 ansible-playbook -i <inventory> notifications_db_merge.yml
 ```
 
-## Precondition: the service must qualify usernames first
+## Ordering: qualification ships with the repoint, not before it
 
-**Run this only after the notifications service has been changed to append
-`uid_domain` to usernames.** The standalone database stores bare usernames
-(`jdoe`); `public.users` stores qualified ones (`jdoe@iplantcollaborative.org`).
-The service writes table names unqualified and normalizes nothing, and its user
-upsert is `INSERT INTO users (username) ... ON CONFLICT (username) DO UPDATE`.
-Pointed at the DE database while still writing bare usernames, it will insert
-them into the `users` table that apps, analyses, and requests all key off.
+Run this playbook while the service is still pointed at the standalone
+database, then repoint it. The username-qualification change and the repointing
+must land in the **same deploy**:
 
-The playbook cannot check this — it is a property of the running service, not
-of the database. It is the one step that has to be sequenced by hand.
+1. Apply `de-database` migrations `000055` and `000056`.
+2. Run this playbook. The service keeps serving from the standalone database,
+   which is left untouched.
+3. Deploy notifications with username qualification **and**
+   `notifications.db.uri` pointed at the DE database, together.
+4. Run this playbook again to sweep up anything recorded between 2 and 3. It is
+   idempotent, so only the gap rows are added.
+
+Qualification cannot ship earlier than the repoint. The standalone database's
+`users` rows are bare, so a qualifying service looks up a username that isn't
+there, creates a second row for the same person, and every listing joins
+through it — their existing notifications vanish from their list.
+
+It cannot ship later either. The service writes every table name unqualified
+and upserts users with `ON CONFLICT (username) DO UPDATE`, so once it is
+pointed at the DE database while still sending bare usernames, it inserts them
+into the `users` table that apps, analyses, and requests all key off.
+
+The playbook cannot check either half — both are properties of the running
+service rather than of the database.
 
 ## What the two identifiers do
 

--- a/wiki/services/notifications.md
+++ b/wiki/services/notifications.md
@@ -4,7 +4,7 @@ title: notifications
 description: User notifications service backed by its own notifications database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
 resource: /ansible/roles/services/notifications
 tags: [notifications, postgresql, amqp, rabbitmq, jobservices, events, email, smtp]
-timestamp: 2026-08-12T00:00:00Z
+timestamp: 2026-08-14T00:00:00Z
 ---
 
 notifications stores and serves DE user notifications. Its config points at a
@@ -17,6 +17,15 @@ port 80; other services reach it via `baseurls_notifications`
 its consumers as `notification_agent.base`. OpenTelemetry tracing is
 explicitly disabled for this service (`OTEL_TRACES_EXPORTER=none` is hardcoded
 in the manifest).
+
+That dedicated database is on its way out. `de-database` migrations `000055`
+and `000056` create `public.notifications` in the DE database, and
+[Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
+moves the rows. The service change that has to land first is username
+qualification: this service stores bare usernames while `public.users` stores
+them suffixed with `uid_domain`, and it writes every table name unqualified, so
+pointing it at the DE database before that change would put bare usernames into
+the shared `users` table.
 
 ## Event recording
 

--- a/wiki/services/notifications.md
+++ b/wiki/services/notifications.md
@@ -23,7 +23,11 @@ and `000056` create `public.notifications` in the DE database, and
 [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
 moves the rows.
 
-The service change that has to land first is username qualification. Callers
+The service change that goes with it is username qualification, and it ships
+in the same deploy as the repoint rather than ahead of it — against the
+standalone database, whose `users` rows are bare, a qualifying service would
+create a second row per person and their existing notifications would drop out
+of their list. Callers
 send bare usernames — apps and terrain both pass `shortUsername` — while the DE
 identifies users by the qualified form, so the service now appends
 `notifications.uid.domain` (rendered from `uid_domain`) before any user lookup.

--- a/wiki/services/notifications.md
+++ b/wiki/services/notifications.md
@@ -21,11 +21,19 @@ in the manifest).
 That dedicated database is on its way out. `de-database` migrations `000055`
 and `000056` create `public.notifications` in the DE database, and
 [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
-moves the rows. The service change that has to land first is username
-qualification: this service stores bare usernames while `public.users` stores
-them suffixed with `uid_domain`, and it writes every table name unqualified, so
-pointing it at the DE database before that change would put bare usernames into
-the shared `users` table.
+moves the rows.
+
+The service change that has to land first is username qualification. Callers
+send bare usernames — apps and terrain both pass `shortUsername` — while the DE
+identifies users by the qualified form, so the service now appends
+`notifications.uid.domain` (rendered from `uid_domain`) before any user lookup.
+It truncates at the first `@` first, matching `apps.user/append-username-suffix`,
+so an account already named as an address resolves to the same DE user every
+other service resolves it to. The setting is required and validated at startup.
+
+Qualification happens only on the way to the database. The username in
+`outgoing_json` and in the `notification.<user>` message stays exactly as the
+caller sent it, because clients read it back out.
 
 ## Event recording
 


### PR DESCRIPTION
Moves the rows of the standalone notifications database into `public.notifications` in the DE database. The schema comes from [cyverse-de/de-database#45](https://github.com/cyverse-de/de-database/pull/45); this is the data move, which can't live in a migration — neither `dblink` nor `postgres_fdw` is installed and `de` isn't superuser.

```bash
ansible-playbook -i <inventory> notifications_db_merge.yml
```

## ⚠️ Precondition the playbook cannot check

**The notifications service must already be appending `uid_domain` to usernames before this runs.** The standalone database stores bare usernames; `public.users` stores qualified ones. The service writes every table name unqualified, normalizes nothing, and upserts users with `ON CONFLICT (username) DO UPDATE` — so pointed at `de` while still writing bare usernames, it will inject them into the `users` table that apps, analyses, and requests all key off. That's a property of the running service, not the database, so it's flagged in the playbook header and the wiki page rather than asserted.

## What it does

Five tagged plays: `dump` → `stage` → `load` → `verify` → `cleanup`.

Both identifiers get rewritten. No account shares an id between the two databases, so every `user_id` is remapped by username, preferring the single-`@` row where the malformed `name@@domain` duplicate also exists — that's the row the rest of the DE references. Types are remapped by name. Notification ids are preserved, because clients hold them: `outgoing_json` embeds the id as `message.id` and the update endpoints address notifications by it.

**The staging schema is hand-written and the rows arrive by `\copy`, not by restoring the dump.** `pg_dump` qualifies every object as `public`, so retargeting it at another schema means running a rewrite over a file that also contains the jsonb payloads — where `public.` could plausibly appear inside a message. The dump is still taken, purely as the rollback artifact.

The notifications service creates a user row on demand for anyone it's notified about, so its user list is **not** a subset of `public.users`. Real people with no DE account are created; iplant-groups subject IDs (which terrain sends as the user for team notifications) are discarded with their notifications, and the verify step reports the count.

## Verification

Full pipeline run against restores of QA's `de` and `notifications` in the local cluster:

| | |
|---|---|
| transform runtime | **9.06 s** for 571,915 rows |
| DE users created | 73 |
| notifications loaded | **571,843** — reconciles exactly with expected |
| discarded | 72, from 30 `@grouper-` subject IDs |
| `unmapped_users` / `unmapped_types` | 0 / 0 |
| re-run | `INSERT 0 0` — idempotent |

**Data integrity:** a per-row md5 over id + both jsonb columns + subject + routing_key + seen + deleted + time_created is identical between source and loaded across all 571,843 rows. 0 mismatched user mappings, 0 mismatched type mappings.

**The double-`@` tiebreak was genuinely exercised**, not just present: QA has 128,111 double-`@` rows and 26,646 staged users matched *both* spellings. Zero notifications landed on a double-`@` user.

Re-run end to end after the lint cleanup, with identical results.

## Lint

`ansible-lint` passes at the **production** profile, 0 failures / 0 warnings. Note this is stricter than the surrounding repo — `db_copy_prod` trips 45 findings and there's no lint config committed. Two deprecated aliases are avoided that the rest of the repo still uses (`port:` → `login_port:`, `database:` → `login_db:`); both are removed in community.postgresql 5.0.0.

## Wiki

New `playbooks/notifications-db-merge.md`, plus updates to `services/notifications.md` and `infrastructure/postgresql.md`, a `log.md` entry, and a regenerated `playbooks/index.md`. `okf check` reports 0 errors, 0 warnings across 77 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)