### PR TITLE
Stop terrain's probes from gating its startup

### DIFF
--- a/ansible/roles/services/terrain/templates/k8s/terrain.yml.j2
+++ b/ansible/roles/services/terrain/templates/k8s/terrain.yml.j2
@@ -100,28 +100,26 @@ spec:
           ports:
             - name: listen-port
               containerPort: 60000
+          # The startup probe gates the other two, so they need no delay of their own.
           livenessProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
             periodSeconds: 20
             timeoutSeconds: 10
           startupProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
-            periodSeconds: 20
-            timeoutSeconds: 10
-            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 5
+            failureThreshold: 150
           readinessProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
-            periodSeconds: 20
-            timeoutSeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
All three of terrain's probes set initialDelaySeconds: 60. Because a startup probe gates the liveness and readiness probes, that delay alone set the floor: a pod could not report ready in under 60s regardless of how fast the JVM started. Terrain's measured JVM load is 2.4s.

The startup probe now polls every 2s with no initial delay, and the liveness and readiness probes rely on it for gating rather than carrying delays of their own. The startup budget goes from 660s to 300s, still a large margin over measured startup.