### PR TITLE
Stop the apps service's probes from gating its startup

### DIFF
--- a/ansible/roles/services/apps/templates/k8s/apps.yml.j2
+++ b/ansible/roles/services/apps/templates/k8s/apps.yml.j2
@@ -91,28 +91,26 @@ spec:
           ports:
             - name: listen-port
               containerPort: 60000
+          # The startup probe gates the other two, so they need no delay of their own.
           livenessProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
             periodSeconds: 20
             timeoutSeconds: 10
           startupProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
-            periodSeconds: 20
-            timeoutSeconds: 10
-            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 5
+            failureThreshold: 150
           readinessProbe:
             httpGet:
               path: /
               port: 60000
-            initialDelaySeconds: 60
-            periodSeconds: 20
-            timeoutSeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
All three of the apps service's probes set initialDelaySeconds: 60. Because a startup probe gates the liveness and readiness probes, that delay alone set the floor: a pod could not report ready in under 60s no matter how fast the JVM started. Measured JVM load for apps is 1.6s, and under 0.8s once its AOT cache lands.

The startup probe now polls every 2s with no initial delay, and the other two rely on it for gating rather than carrying delays of their own. The startup budget goes from 660s to 300s, still a large margin.

The probe target GET / is the status endpoint, which returns the service name and version from memory without touching the database or any other service, so the faster cadence costs nothing.

This mirrors the same change made for terrain.