### PR TITLE
Point notifications.db.uri at the DE database

### DIFF
--- a/ansible/roles/services/notifications/templates/jobservices.yml.j2
+++ b/ansible/roles/services/notifications/templates/jobservices.yml.j2
@@ -89,7 +89,8 @@ notification_agent:
 
 notifications:
   db:
-    uri: "postgresql://{{ dbms_connection_user }}:{{ dbms_connection_pass | urlencode }}@{{ groups['dbms'][0] }}:{{ pg_listen_port }}/{{ notifications_db_name }}?sslmode=disable"
+    # The notifications rows live in the DE database; the standalone one is retired.
+    uri: "postgresql://{{ dbms_connection_user }}:{{ dbms_connection_pass | urlencode }}@{{ groups['dbms'][0] }}:{{ pg_listen_port }}/{{ de_db_name }}?sslmode=disable"
   uid:
     # Callers send bare usernames; the DE identifies users by the qualified form.
     domain: "{{ uid_domain }}"

--- a/notes/notifications-merge-collision-repair.sql
+++ b/notes/notifications-merge-collision-repair.sql
@@ -1,0 +1,145 @@
+-- Repair the duplicate notification user rows created by a half-completed
+-- cutover, so notifications_db_merge.yml can be re-run.
+--
+-- Run against the STANDALONE notifications database -- NOT the `de` database,
+-- where the "@domain" suffix is the correct storage format and stripping it
+-- would corrupt every user row. The guard below refuses to run in the wrong
+-- place.
+--
+-- DRY RUN BY DEFAULT. Everything runs in one transaction and reports what it
+-- changed; the transaction is rolled back unless you pass -v apply=1.
+--
+--   dry run:  psql -h <host> -U <user> -d notifications -f notifications-merge-collision-repair.sql
+--   apply:    psql -h <host> -U <user> -d notifications -v apply=1 -f notifications-merge-collision-repair.sql
+--
+-- Why the duplicates exist: the notifications service ships username
+-- qualification and the repoint onto the DE database in the same deploy. If
+-- the qualification half lands alone, the service keeps writing to the
+-- standalone database -- whose users rows are bare -- and its lookup for
+-- "jdoe@<uid_domain>" misses the existing "jdoe" row, so it creates a second
+-- one. The person's history then splits across two rows, and both spellings
+-- qualify to the same DE username, which trips the colliding_users check in
+-- the merge role's verify.sql.
+--
+-- This script consolidates each such pair back onto the bare row. Run it after
+-- the service has actually been repointed, otherwise it will just recreate the
+-- duplicates on the next notification.
+--
+-- Deliberately NOT touched: rows whose username is an address at some other
+-- domain, e.g. "stephen.wright@utoronto.ca". Those are long-standing rows, not
+-- artifacts of the bad deploy, and the merge already resolves them correctly by
+-- truncating at the first '@'.
+
+\pset border 2
+\timing on
+\set ON_ERROR_STOP on
+
+\if :{?apply}
+\else
+  \set apply 0
+\endif
+
+\if :{?uid_domain}
+\else
+  \set uid_domain iplantcollaborative.org
+\endif
+
+-- Abort if this isn't the standalone notifications database. Both it and the
+-- DE database have a public.users table, and this script would strip the
+-- suffix from every DE user if pointed at the wrong one.
+DO $$
+BEGIN
+  IF to_regclass('public.notifications') IS NULL
+     OR to_regclass('public.notification_types') IS NULL THEN
+    RAISE EXCEPTION
+      'No notifications schema here (current_database() = %). Re-run with -d notifications.',
+      current_database();
+  END IF;
+
+  IF to_regclass('public.jobs') IS NOT NULL OR to_regclass('public.apps') IS NOT NULL THEN
+    RAISE EXCEPTION
+      'This is the DE database (current_database() = %), where qualified usernames are correct. Refusing to run.',
+      current_database();
+  END IF;
+END
+$$;
+
+BEGIN;
+
+-- Each qualified row the bad deploy created, paired with the bare row that
+-- already held the person's history.
+CREATE TEMPORARY TABLE dup_pair ON COMMIT DROP AS
+SELECT dup.id       AS dup_id,
+       dup.username AS dup_username,
+       bare.id      AS bare_id,
+       bare.username AS bare_username
+FROM users dup
+JOIN users bare
+  ON bare.username = regexp_replace(dup.username, '@.*$', '')
+WHERE dup.username = regexp_replace(dup.username, '@.*$', '') || '@' || :'uid_domain';
+
+\echo ''
+\echo '=== Plan: duplicate rows to fold back onto the bare user ==='
+SELECT p.dup_username,
+       (SELECT count(*) FROM notifications n WHERE n.user_id = p.dup_id)  AS moving,
+       p.bare_username,
+       (SELECT count(*) FROM notifications n WHERE n.user_id = p.bare_id) AS already_there
+FROM dup_pair p
+ORDER BY p.dup_username;
+
+\echo ''
+\echo '=== Left alone: qualified rows at other domains, and rows with no bare counterpart ==='
+SELECT u.username,
+       (SELECT count(*) FROM notifications n WHERE n.user_id = u.id) AS notifications
+FROM users u
+WHERE u.username LIKE '%@%'
+  AND u.username NOT LIKE '@grouper-%'
+  AND u.id NOT IN (SELECT dup_id FROM dup_pair)
+ORDER BY u.username;
+
+\echo ''
+\echo '=== Step 1: repoint notifications onto the bare user ==='
+WITH moved AS (
+  UPDATE notifications n
+     SET user_id = p.bare_id
+    FROM dup_pair p
+   WHERE n.user_id = p.dup_id
+  RETURNING p.dup_username
+)
+SELECT dup_username, count(*) AS notifications_moved
+FROM moved GROUP BY dup_username ORDER BY dup_username;
+
+\echo ''
+\echo '=== Step 2: delete the emptied duplicate user rows ==='
+WITH gone AS (
+  DELETE FROM users u
+   WHERE u.id IN (SELECT dup_id FROM dup_pair)
+     AND NOT EXISTS (SELECT 1 FROM notifications n WHERE n.user_id = u.id)
+  RETURNING u.username
+)
+SELECT username AS deleted_user FROM gone ORDER BY username;
+
+\echo ''
+\echo '=== After: collisions the merge would still see (must be empty) ==='
+SELECT de_username, count(*) AS staged_accounts,
+       string_agg(username, ' + ' ORDER BY username) AS spellings
+FROM (
+  SELECT id, username,
+         regexp_replace(username, '@.*$', '') || '@' || :'uid_domain' AS de_username
+  FROM users
+  WHERE username NOT LIKE '@grouper-%'
+) s
+GROUP BY de_username HAVING count(*) > 1
+ORDER BY de_username;
+
+\if :apply
+COMMIT;
+\echo ''
+\echo '*** APPLIED AND COMMITTED ***'
+\echo '*** Now re-run notifications_db_merge.yml to sweep the gap rows into the DE database. ***'
+\else
+ROLLBACK;
+\echo ''
+\echo '*** DRY RUN -- everything above was rolled back. ***'
+\echo '*** Re-run with -v apply=1 to apply it.          ***'
+\endif

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,22 @@
 # Wiki Update Log
 
+## 2026-08-18
+
+* **Update**: [notifications](/services/notifications.md) — `notifications.db.uri`
+  now renders from `de_db_name` rather than `notifications_db_name`. The
+  username-qualification change had shipped without the repoint that is
+  supposed to travel with it, so the service was still writing to the
+  standalone database while qualifying usernames. Corrects the opening
+  paragraph and the configuration section, which both still described the
+  dedicated database as the one the service connects to.
+* **Update**: [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
+  — adds a recovery section for a half-completed cutover: what a
+  qualification-without-repoint deploy does to the standalone database, why it
+  then trips the `colliding_users` check on the next run, and how
+  `notes/notifications-merge-collision-repair.sql` folds the duplicate user row
+  back onto the bare one so the merge can be re-run. Notes that the service has
+  to be repointed first or the duplicate returns.
+
 ## 2026-08-14
 
 * **Add**: [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)

--- a/wiki/playbooks/notifications-db-merge.md
+++ b/wiki/playbooks/notifications-db-merge.md
@@ -4,7 +4,7 @@ title: Merging the Notifications Database into DE
 description: How notifications_db_merge.yml moves the standalone notifications database into the DE database's public schema, remapping user and notification-type identifiers on the way.
 resource: /ansible/notifications_db_merge.yml
 tags: [notifications, postgresql, migration, database, de-database]
-timestamp: 2026-08-14T00:00:00Z
+timestamp: 2026-08-18T00:00:00Z
 ---
 
 The [notifications](/services/notifications.md) service has always kept its own
@@ -49,6 +49,32 @@ into the `users` table that apps, analyses, and requests all key off.
 
 The playbook cannot check either half — both are properties of the running
 service rather than of the database.
+
+## Recovering from a half-completed cutover
+
+If step 3 lands qualification without the repoint — the deploy that shipped
+`notifications.uid.domain` while `notifications.db.uri` still named
+`notifications_db_name` — the service keeps writing to the standalone database
+while qualifying usernames. Its lookup for `jdoe@<uid_domain>` misses the bare
+`jdoe` row, so it creates a second one: the person's existing notifications
+drop out of their list, and new rows accumulate under an account the merge has
+no clean home for.
+
+That leaves both spellings qualifying to the same DE username, so the next run
+of this playbook fails `colliding_users` rather than silently combining them.
+The check is doing its job; the fix is to fold the duplicate back before
+re-running.
+
+`notes/notifications-merge-collision-repair.sql` does that, against the
+**standalone** database. It repoints the stray rows onto the bare user, deletes
+the emptied duplicate, and re-reports the collision check. It is a dry run
+unless passed `-v apply=1`, and it refuses to run against the DE database,
+where the qualified spelling is the correct one. Repoint and redeploy the
+service first — run against a service still writing bare-to-qualified and the
+duplicate simply comes back.
+
+Rows written to the standalone database during the gap are swept up by the
+final playbook run, since the ids are preserved and the load is idempotent.
 
 ## What the two identifiers do
 
@@ -144,3 +170,4 @@ read — only once the service has been cut over and verified.
 [2] `ansible/roles/notifications_db_merge/` — role tasks, defaults, and SQL.
 [3] [notifications](/services/notifications.md) — the service that owns these rows.
 [4] [PostgreSQL](/infrastructure/postgresql.md) — the DBMS and its databases.
+[5] `notes/notifications-merge-collision-repair.sql` — duplicate-user repair for a half-completed cutover.

--- a/wiki/services/index.md
+++ b/wiki/services/index.md
@@ -19,7 +19,7 @@
 * [kifshare](/services/kifshare.md) - Public download page for files shared from the data store via iRODS tickets.
 * [maintenance-page](/services/maintenance-page.md) - Maintenance-mode page that redirects DE traffic to itself by rewriting the environment's Gateway API HTTPRoutes.
 * [metadata](/services/metadata.md) - DE metadata service backed by its own metadata database on PostgreSQL.
-* [notifications](/services/notifications.md) - User notifications service backed by its own notifications database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
+* [notifications](/services/notifications.md) - User notifications service backed by the DE database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
 * [openldap-docker](/services/openldap-docker.md) - In-cluster OpenLDAP directory for DE deployments without an external LDAP server, deployed as a StatefulSet with config and seed data rendered from templates.
 * [permissions](/services/permissions.md) - DE permissions service backed by its own PostgreSQL database, with read access to the Grouper database for group information.
 * [portal-conductor](/services/portal-conductor.md) - Account-provisioning API used by the user portal, acting on LDAP, iRODS, terrain, Mailman, and formation, with an exim sidecar for outbound mail.

--- a/wiki/services/notifications.md
+++ b/wiki/services/notifications.md
@@ -1,27 +1,29 @@
 ---
 type: Service
 title: notifications
-description: User notifications service backed by its own notifications database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
+description: User notifications service backed by the DE database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
 resource: /ansible/roles/services/notifications
 tags: [notifications, postgresql, amqp, rabbitmq, jobservices, events, email, smtp]
-timestamp: 2026-08-14T00:00:00Z
+timestamp: 2026-08-18T00:00:00Z
 ---
 
-notifications stores and serves DE user notifications. Its config points at a
-dedicated database — `notifications_db_name` (default `notifications`) on the
-[PostgreSQL](/infrastructure/postgresql.md) DBMS host — alongside the DE
-database and the [RabbitMQ](/infrastructure/rabbitmq.md) `de` topic exchange.
-It listens on port 8080, exposed in-cluster as Service `notifications` on
-port 80; other services reach it via `baseurls_notifications`
+notifications stores and serves DE user notifications. Its config points at the
+DE database — `de_db_name` on the [PostgreSQL](/infrastructure/postgresql.md)
+DBMS host — alongside the [RabbitMQ](/infrastructure/rabbitmq.md) `de` topic
+exchange. It listens on port 8080, exposed in-cluster as Service
+`notifications` on port 80; other services reach it via `baseurls_notifications`
 (`http://notifications/v1`), which the shared job-services template exposes to
 its consumers as `notification_agent.base`. OpenTelemetry tracing is
 explicitly disabled for this service (`OTEL_TRACES_EXPORTER=none` is hardcoded
 in the manifest).
 
-That dedicated database is on its way out. `de-database` migrations `000055`
-and `000056` create `public.notifications` in the DE database, and
+It used to keep a dedicated database of its own. `de-database` migrations
+`000055` and `000056` create `public.notifications` in the DE database, and
 [Merging the Notifications Database into DE](/playbooks/notifications-db-merge.md)
-moves the rows.
+moves the rows; `notifications.db.uri` renders from `de_db_name` as of the
+2026-08-18 repoint. The standalone database is left running and still holds the
+pre-merge rows — retire it only once every environment has been cut over and
+verified.
 
 The service change that goes with it is username qualification, and it ships
 in the same deploy as the repoint rather than ahead of it — against the
@@ -142,8 +144,9 @@ The role renders the shared job-services template
 `templates/jobservices.yml.j2` into the `notifications-configs` secret,
 mounted at `/etc/iplant/de/jobservices.yml`. The operative section is
 `notifications.db.uri`, built from `dbms_connection_user`/
-`dbms_connection_pass`, `groups['dbms'][0]`, `pg_listen_port`, and
-`notifications_db_name`; the AMQP URI comes from the `de_amqp_*` group_vars.
+`dbms_connection_pass`, `groups['dbms'][0]`, `pg_listen_port`, and `de_db_name`
+— the key is named for the service, not for the database it points at; the AMQP
+URI comes from the `de_amqp_*` group_vars.
 The `de:` and `email:` blocks drive outbound mail. The rest of the shared
 template (Condor, iRODS, VICE, Keycloak, Harbor) is common boilerplate across
 the job services. Defaults: `notifications_replicas: 2` with required pod


### PR DESCRIPTION
## What happened

The notifications merge ships username qualification and the repoint onto the DE database **in the same deploy** on purpose. Only the qualification half landed: `notifications.uid.domain` was rendered, but `notifications.db.uri` still named `notifications_db_name`.

So the deployed service kept writing to the standalone database while qualifying usernames — the exact state the documented ordering exists to prevent.

## Validation against QA

The merge itself is sound. Reconciled the standalone database against `de`:

| Check | Result |
| --- | --- |
| `schema_migrations` | version 56, not dirty |
| `notification_types` | table (not enum), all 9 names seeded |
| Count | 571,921 src − 72 junk − 6 gap = **571,843** = exactly what landed in `de` |
| **Content checksum** | `329903238564857732307470` on **both** sides, 571,843 rows |
| `@@` malformed user mappings | 0 |
| grouper/junk users in `de` | 0 |
| `stephen.wright` edge case | 4 notifications → `stephen.wright@iplantcollaborative.org`; both stray spellings 0 |
| Staging schema | dropped |
| Orphans / null payloads | 0 / 0 / 0 |

The checksum covers id, qualified username, type name, subject, seen, deleted, time_created, and hashes of both JSON payloads — every migrated row is byte-identical.

The cutover is what went wrong:

- Notifications pods hold **zero** connections to `de`; two idle connections to the standalone DB, opened at pod start.
- 6 notifications written to the standalone DB after the rollout, absent from `de`.
- The standalone DB grew a duplicate `wregglej@iplantcollaborative.org` row beside the bare `wregglej` row that holds 2,280 notifications — which are consequently invisible in the DE UI right now.

## Changes

1. **`roles/services/notifications/templates/jobservices.yml.j2`** — render `notifications.db.uri` from `de_db_name`. The key stays named for the service rather than the database it points at, so that's noted inline.

2. **`notes/notifications-merge-collision-repair.sql`** — the duplicate row makes both spellings qualify to one DE username, tripping `colliding_users` on the next merge run. This folds the duplicate back onto the bare user. Dry run unless given `-v apply=1`; refuses to run against the DE database, where the qualified spelling is correct. Follows the existing `qms-user-repair.sql` convention.

   Dry-run and guard both verified against QA — finds the one pair, moves 6 rows, correctly leaves `stephen.wright@utoronto.ca` alone, and the post-check reports zero collisions.

3. **Wiki** — corrected `services/notifications.md` (opening paragraph and configuration section both still described the dedicated database as the connection target) and added a recovery section to `playbooks/notifications-db-merge.md`. `okf index` + `okf check`: 0 errors, 0 warnings.

## Deploying this

Order matters:

1. Merge this, then **deploy notifications** — stops new rows landing in the standalone DB.
2. Run the repair script with `-v apply=1` against the standalone DB.
3. Re-run `notifications_db_merge.yml` to sweep the 6 gap rows.

Running step 2 before step 1 just lets the service recreate the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)