### PR TITLE
Record why a data-info share can succeed without granting anything

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,19 @@
 
 ## 2026-08-18
 
+* **Update**: [data-info](/services/data-info.md) — documents why a share can
+  succeed without granting anything. `share-path` skips when the recipient
+  already holds the requested permission, but it tests the aggregated
+  (group-inclusive) permission while the share it skips would have written a
+  direct ACL. Since every account is in `public` and home directories inherit a
+  `public` read ACL, sharing under a home directory at read routinely skips: the
+  request succeeds, the UI notifies, and the recipient never appears in the
+  shared-with list. Records the consequence beyond the display — the access
+  rests on the group membership that suppressed the ACL, so it disappears
+  silently if that membership changes — plus how to confirm it from the
+  `already-shared` reason, and why statting as the recipient is not a valid
+  check.
+
 * **Update**: [notifications](/services/notifications.md) — `notifications.db.uri`
   now renders from `de_db_name` rather than `notifications_db_name`. The
   username-qualification change had shipped without the repoint that is

--- a/wiki/services/data-info.md
+++ b/wiki/services/data-info.md
@@ -4,7 +4,7 @@ title: data-info
 description: HTTP API for data-store operations — file and folder metadata, permissions, path lists, and anonymous-access URLs backed by iRODS.
 resource: /ansible/roles/services/data-info
 tags: [data, irods, icat, files, de]
-timestamp: 2026-07-20T00:00:00Z
+timestamp: 2026-08-18T00:00:00Z
 ---
 
 data-info is the DE's data-store API. It is a JVM service (the pod sets
@@ -25,9 +25,62 @@ and [metadata](/services/metadata.md) services, and connects to the DE
 Deploy with `ansible-playbook -i $INVENTORY deploy_it.yml --tags data-info` —
 see [Building and Deploying Services](/playbooks/build-and-deploy.md).
 
+## Sharing skips when the recipient already has the permission via a group
+
+One trap worth knowing, because it looks like a successful share that quietly
+does nothing. Before granting access, data-info checks whether the recipient
+already holds the requested permission, and skips the share if they do. That
+check reads the recipient's **aggregated** permission — clj-jargon's
+`permission-for` takes the maximum across every ACL that applies, including the
+ones they inherit through group membership — but the share it skips would have
+written a **direct** ACL on the object.
+
+The two are not the same thing, and the DE routinely puts them out of step.
+Every account belongs to `public`, and home directories usually carry a
+`public` read ACL that new children inherit. So sharing anything under a home
+directory with another user **at read** finds "they already have read", skips,
+and writes no ACL row. The request returns success and the UI raises its
+success notification, but the recipient never appears in the list of people the
+item is shared with — that list shows direct ACLs. Sharing the same user at
+`write` or `own` works and shows up immediately, because the aggregated
+permission no longer equals what was asked for.
+
+The same asymmetry explains why re-sharing usually looks fine: once a direct
+ACL exists, a repeat share at the same level also skips, but the row is already
+there, so nothing looks wrong. And lowering someone from `own` to `read`
+applies, because `own` does not equal `read` — it rewrites the existing row
+rather than skipping.
+
+The missing row matters beyond the display. A skipped share is never persisted
+as an ACL, so the access rests entirely on the group membership that suppressed
+it. If that membership changes, the sharing silently disappears, and there is
+no record that anyone ever shared the item.
+
+This is long-standing behavior, not a regression. It affects both
+`PUT /data/:data-id/permissions/:share-with/:permission` and the bulk
+`POST /sharer`, since both route through the same guard. The bulk endpoint at
+least reports `"reason": "already-shared"` on the skipped entry, which is the
+quickest way to confirm you are looking at this and not something else:
+
+```bash
+# skipped: recipient already has read via public
+curl -s -X POST "$DATA_INFO/sharer?user=$OWNER" -H 'Content-Type: application/json' \
+  -d '{"sharing":[{"user":"'$RECIPIENT'","paths":[{"path":"'$PATH'","permission":"read"}]}]}'
+
+# ground truth — direct ACLs only
+curl -s -X POST "$DATA_INFO/permissions-gatherer?user=$OWNER" \
+  -H 'Content-Type: application/json' -d '{"paths":["'$PATH'"]}'
+```
+
+Note that statting the path as the recipient is **not** a valid check: it
+reports the aggregated permission, so it returns `read` whether the share
+landed or not.
+
 # Citations
 
 1. `ansible/roles/services/data-info/templates/data-info.properties.j2` — iRODS/ICAT/AMQP config, anon-files mappings, dependent service URLs.
 2. `ansible/roles/services/data-info/files/data-info.json` — pinned image name and digest.
 3. `ansible/roles/services/data-info/templates/k8s/data-info.yml.j2` — Deployment/Service, port 60000, JAVA_TOOL_OPTIONS, OTEL env.
 4. `ansible/roles/services/data-info/tasks/main.yml` — creates the `data-info-configs` secret, then runs deploy-service.
+5. [`data_info/services/sharing.clj`](https://github.com/cyverse-de/data-info/blob/main/src/data_info/services/sharing.clj) — `share-path` guards on `shared?`, which compares the requested permission against `permission-for`.
+6. [`clj-jargon permissions.clj`](https://github.com/cyverse-de/clj-jargon/blob/master/src/clj_jargon/permissions.clj) — `permission-for` returns the aggregated (group-inclusive) permission; `list-user-perm`, behind `permissions-gatherer`, returns direct ACLs.


### PR DESCRIPTION
Adds a "trap worth knowing" section to [`wiki/services/data-info.md`](wiki/services/data-info.md), plus a `wiki/log.md` entry.

## What this documents

A share can report success, raise a success notification in the UI, and grant nothing.

`share-path` skips the share when the recipient already holds the requested permission. That check reads the recipient's **aggregated** permission — clj-jargon's `permission-for` takes the maximum across every applicable ACL, group memberships included — but the share it skips would have written a **direct** ACL on the object.

Those two routinely diverge here. Every account is in `public`, and home directories carry a `public` read ACL that new children inherit. So sharing anything under a home directory with another user **at read** finds "they already have read", skips, and writes no ACL row. The recipient never appears in the shared-with list, because that list shows direct ACLs.

The same equality check explains the behaviors that look inconsistent from the outside:

| starting state | share at | result |
| --- | --- | --- |
| no direct ACL, `read` via `public` | `read` | skipped, no row written, invisible |
| no direct ACL, `read` via `public` | `own` | applied, appears |
| direct ACL `own` | `read` | applied as a downgrade, appears |
| direct ACL `read` | `read` | skipped, but the row already exists so nothing looks wrong |

That last row is why this has stayed hidden: re-sharing someone already explicitly shared also skips, harmlessly.

## Why it's worth writing down

The missing row isn't only cosmetic. A skipped share is never persisted as an ACL, so the access rests entirely on the group membership that suppressed it — if that membership changes, the sharing disappears silently, with no record that anyone ever shared the item.

The page also records how to tell this apart from a real failure (`"reason": "already-shared"` on the bulk `/sharer` response, `permissions-gatherer` for ground truth) and one trap that cost time during diagnosis: statting the path as the recipient is **not** a valid check, since it reports the aggregated permission and returns `read` whether the share landed or not.

## Scope

This is long-standing behavior, **not** a regression. It was confirmed against the untouched `PUT /data/:data-id/permissions/:share-with/:permission` endpoint, which behaves identically — both route through the same guard. No code change here; this PR only records the behavior. Fixing it means comparing against the direct ACL rather than the aggregate, which changes what `already-shared` means for every caller and would start writing ACLs where shares currently no-op — a decision worth making deliberately.

Reproduced on QA against `data-info` and `clj-jargon 3.1.5`.

## Validation

`okf index` wrote nothing (title and description unchanged); `okf check` reports 0 errors, 0 warnings across 77 files.

Per `updating-the-wiki`, I also swept the `ansible/` files touched in the same session — the two build descriptors are cited by `wiki/services/data-info.md` and `wiki/services/terrain.md`, but both pages describe them generically as "pinned by digest in the build descriptor" without quoting a digest, so neither went stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)