### PR TITLE
Give info-typer an HTTP endpoint, and fix two config bugs

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -131,6 +131,7 @@ baseurls_async_tasks: http://async-tasks
 baseurls_dashboard_aggregator: http://dashboard-aggregator
 baseurls_data_info: http://data-info
 baseurls_grouper_web_services: http://grouper-ws/grouper-ws
+baseurls_info_typer: http://info-typer
 baseurls_iplant_email: http://notifications/mail
 baseurls_iplant_groups: http://iplant-groups
 baseurls_job_status: http://job-status

--- a/ansible/roles/services/info-typer/templates/info-typer.properties.j2
+++ b/ansible/roles/services/info-typer/templates/info-typer.properties.j2
@@ -1,4 +1,5 @@
 info-typer.environment-name     = {{ ns }}
+info-typer.port                 = 60000
 
 info-typer.type-attribute       = ipc-filetype
 info-typer.filetype-read-amount = 1024
@@ -15,7 +16,5 @@ info-typer.irods.home        = /{{ irods_zone }}/home
 
 # AMQP settings
 info-typer.amqp.uri                  = amqp://{{ irods_amqp_user }}:{{ irods_amqp_password | urlencode }}@{{ irods_amqp_host }}:{{ irods_amqp_port }}/{{ irods_amqp_vhost | urlencode | regex_replace('\/', '%2F') }}
-info-typer.amqp.exchange.name        = irods
+info-typer.amqp.exchange             = irods
 info-typer.amqp.qos                  = 100
-
-info-typer.events.amqp.uri = amqp://{{ de_amqp_user }}:{{ de_amqp_password | urlencode }}@{{ de_amqp_host }}:{{ de_amqp_port }}/{{ de_amqp_vhost | urlencode | regex_replace('\/', '%2F') }}

--- a/ansible/roles/services/info-typer/templates/k8s/info-typer.yml.j2
+++ b/ansible/roles/services/info-typer/templates/k8s/info-typer.yml.j2
@@ -69,3 +69,41 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: OTEL_EXPORTER_JAEGER_ENDPOINT
+          ports:
+            - name: listen-port
+              containerPort: 60000
+          # GET / here answers from memory -- it reports whether the AMQP consumer is
+          # connected but does not talk to the broker or to iRODS -- so all three probes can
+          # poll at the usual rate. That is unlike data-info, whose GET / opens an iRODS
+          # connection on every call.
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 60000
+            periodSeconds: 20
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /
+              port: 60000
+            periodSeconds: 3
+            timeoutSeconds: 10
+            failureThreshold: 100
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 60000
+            periodSeconds: 20
+            timeoutSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: info-typer
+spec:
+  selector:
+    de-app: info-typer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: listen-port

--- a/ansible/roles/services/terrain/templates/terrain.properties.j2
+++ b/ansible/roles/services/terrain/templates/terrain.properties.j2
@@ -115,6 +115,7 @@ terrain.fileio.url-import-app = 1E8F719B-0452-4D39-A2F3-8714793EE3E6
 
 # Filesystem settings
 terrain.data-info.base-url            = {{ baseurls_data_info|string|regex_replace("\/$","") }}
+terrain.info-typer.base-url           = {{ baseurls_info_typer|string|regex_replace("\/$","") }}
 terrain.fs.community-data             = /{{ irods_zone }}/home/shared
 terrain.fs.bad-names                  = cacheServiceTempDir
 terrain.fs.perms-filter               = {{ irods_perms_filter | join(",") }}


### PR DESCRIPTION
Part of moving file-type detection out of data-info. Branch `move-file-types-to-info-typer`
exists in `info-typer`, `terrain`, `deployments` and `data-info`.

info-typer is gaining an HTTP API ([info-typer#14](https://github.com/cyverse-de/info-typer/pull/14)),
so it needs to be reachable: a container port, a Service, probes, and a base URL for terrain to
call it at.

## Probe rates

All three probes poll at the usual rate. `GET /` on info-typer answers from memory — it reports
whether the AMQP consumer is connected without talking to the broker or to iRODS — so it does
not need data-info's slower liveness and readiness periods, which exist only because
data-info's `GET /` opens an iRODS connection on every call.

## Two bugs found while adding the port

- **`info-typer.amqp.exchange.name` has never been read.** The code looks for
  `info-typer.amqp.exchange`, so the configured value was ignored and the service ran on its
  default. It worked only because the default happens to be the same string — which would have
  stopped being true the moment anyone changed the exchange.
- **`info-typer.events.amqp.uri` is read by nothing at all**, and it puts the DE broker's
  credentials into this service's secret for no reason. Removed.

## Deploy order

This should go out **before** the terrain change, so info-typer is answering when terrain is
repointed. data-info keeps serving the same endpoints throughout, so terrain can be pointed
back by changing one property if anything is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)