### PR TITLE
Resolve a build ref that exists only on the remote

### DIFF
--- a/ansible/roles/build-service/tasks/main.yml
+++ b/ansible/roles/build-service/tasks/main.yml
@@ -43,11 +43,55 @@
           changed_when: false
           failed_when: false
 
+        # A bare name resolves under refs/heads, refs/tags and refs/remotes/<name>,
+        # but never refs/remotes/origin/<name>. The fetch above makes tags local
+        # refs and a clone gets its default branch, so those resolve -- a branch
+        # living only on the remote does not. Resolve the ref here and hand the
+        # worktree a SHA, so no local branch has to be created in the source
+        # checkout to make the ref reachable. Only the checkout takes the SHA --
+        # git_ref stays the human name that reaches skaffold's --tag below, which
+        # rejects a slash (an `origin/<ref>` tag is not a valid image tag).
+        - name: resolve the requested ref to a commit
+          delegate_to: localhost
+          ansible.builtin.command:
+            chdir: "{{ source_repo }}"
+            cmd: git rev-parse --verify --quiet {{ git_ref }}^{commit}
+          register: git_ref_local
+          changed_when: false
+          failed_when: false
+
+        - name: resolve the requested ref against the remote
+          delegate_to: localhost
+          when: git_ref_local.rc != 0
+          ansible.builtin.command:
+            chdir: "{{ source_repo }}"
+            cmd: git rev-parse --verify --quiet origin/{{ git_ref }}^{commit}
+          register: git_ref_remote
+          changed_when: false
+          failed_when: false
+
+        - name: record the resolved commit
+          delegate_to: localhost
+          ansible.builtin.set_fact:
+            build_commit: "{{ git_ref_local.stdout if git_ref_local.rc == 0 else git_ref_remote.stdout | default('') }}"
+
+        # Fail here rather than let an empty SHA reach git worktree add, which
+        # would check out HEAD and silently build the wrong tree.
+        - name: ensure the requested ref resolved
+          delegate_to: localhost
+          ansible.builtin.assert:
+            that:
+              - build_commit | length > 0
+            fail_msg: >-
+              git_ref {{ git_ref }} names no commit in {{ source_repo }}, either
+              directly or as origin/{{ git_ref }}. Check the ref name, or re-run
+              clone_sources.yml if the checkout is missing or stale.
+
         - name: check out the requested ref in a worktree
           delegate_to: localhost
           ansible.builtin.command:
             chdir: "{{ source_repo }}"
-            cmd: git worktree add --force --detach {{ build_tmp.path }}/repo {{ git_ref }}
+            cmd: git worktree add --force --detach {{ build_tmp.path }}/repo {{ build_commit }}
 
         # The deployments repo is the source of truth for skaffold.yaml and the
         # k8s manifests, so overlay them onto the source tree before building.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-21
 
+* **Update**: [Building and Deploying Services](/playbooks/build-and-deploy.md)
+  — `git_ref` is now resolved to a commit, falling back to `origin/<ref>`,
+  before the build worktree is created. A branch that existed only on the remote
+  used to fail outright, because a bare name never resolves under
+  `refs/remotes/origin/<name>`; only tags and the clone's default branch did.
+  The source checkout still gains no local branch.
+
 * **Update**: [Continuous Integration Builds](/playbooks/ci-to-qa.md) (was
   "Continuous Integration to QA"), plus the `build_json_dir` notes in
   [Building and Deploying Services](/playbooks/build-and-deploy.md),

--- a/wiki/playbooks/build-and-deploy.md
+++ b/wiki/playbooks/build-and-deploy.md
@@ -4,7 +4,7 @@ title: Building and Deploying Services
 description: How service container images are built from source with build_it.yml and build_release.yml, and deployed with deploy_it.yml.
 resource: /ansible/BUILD_DEPLOY.md
 tags: [build, deploy, release, skaffold, ansible]
-timestamp: 2026-07-31T12:00:00Z
+timestamp: 2026-08-21T22:27:54Z
 ---
 
 This repo is the source of truth for build and deploy configuration: each
@@ -51,7 +51,10 @@ ansible-playbook -i "$QA_INVENTORY" deploy_it.yml --tags app-exposer
   automatically.
 * Builds check out a temporary git worktree at `git_ref`; the source checkout
   is never modified, and the changed descriptor is never committed — review and
-  commit it yourself.
+  commit it yourself. `git_ref` may be a tag, a local branch, or a branch that
+  exists only on the remote — it is resolved to a commit, falling back to
+  `origin/<ref>`, before the worktree is made, so no local branch is created in
+  the checkout. A ref that resolves to neither fails by name.
 * Builds write descriptors into the service role's own `files/` directory, and
   deploys read from `build_json_dir`, which resolves to that same directory. If
   a freshly built image isn't picked up on deploy, the build most likely never


### PR DESCRIPTION
`build_it.yml --tags <svc>` fails on a freshly cloned source checkout whenever the service's `git_ref` is a non-default *branch*:

```
git worktree add --force --detach /tmp/.../repo golang
fatal: invalid reference: golang
```

`git worktree add` takes a commit-ish, and per gitrevisions a bare name is looked up under `refs/heads`, `refs/tags`, `refs/remotes/<name>` and `refs/remotes/<name>/HEAD` — **never** `refs/remotes/origin/<name>`. `build-service` fetches with `git fetch --tags --force origin`, so tags become local refs, and a clone gets its default branch locally. Both of those have always resolved. A branch that exists only on the remote never does.

Nothing hit this while every service built a tag or `main`. `data-info-next` is the first service pinned to a non-default branch (`data_info_next_git_ref: golang`, because data-info's `main` carries no Go tree), so it's the first to trigger a latent bug in shared infrastructure. This is deliberately a standalone change rather than part of #107, since the fix belongs to `build-service` and nothing else depends on it.

## The change

Resolve `git_ref` to a commit before creating the worktree, falling back to `origin/<ref>`, and hand the worktree that SHA.

**The invariant most likely to be broken by a later "simplification": only the worktree checkout takes the SHA.** `git_ref` stays the human name that reaches `skaffold build --tag`. Collapsing `git_ref` into `build_commit` everywhere looks tidy and produces digest-named image tags; the same trap catches anyone reaching for `-e git_ref=origin/golang` as a workaround, which yields the invalid image tag `…:origin/golang`. There's a comment on the resolution block saying so.

Two smaller notes:

* It's four tasks rather than one, because Ansible's `command` module runs no shell, so a `||` fallback chain isn't available. Each step's failure stays legible as a result.
* An unresolvable ref now fails at an explicit `assert` naming the ref and both forms tried. Previously a typo died at `invalid reference`, which at least named it; letting an empty SHA reach `git worktree add` would check out `HEAD` and silently build the wrong tree, which is much worse.

The source checkout still gains no local branch, so `build-service`'s documented "your checkout is never modified" promise holds.

## Verification

Ran against `data-info-next` with `push_images=false`, after deleting the local `golang` branch from the source checkout to restore genuine fresh-clone state — testing the fallback with a local ref still present proves nothing.

| Case | Result |
| --- | --- |
| Branch only on the remote | fallback task fires, build completes, `ok=17 failed=0` |
| Local ref present | fallback reports `skipping`, local path taken, `ok=20 failed=0` |
| `-e git_ref=nosuchbranch` | fails at the assert: "names no commit in … either directly or as origin/nosuchbranch" |
| After every run | `git branch` in the source checkout still only `main`; `git worktree list` shows no leftovers |
| Image tag | `harbor.cyverse.org/de/data-info-next:golang` — the human name, not a SHA |

ansible-lint checked as a delta, since the role already trips a fair amount by house style. Before: 16 `name[casing]`, 3 `no-changed-when`, 3 `command-instead-of-module`. After: 20 `name[casing]`, everything else unchanged — the four new lowercase task names, matching the file's existing convention. No new rule classes; the `rev-parse` tasks carry `changed_when: false`.

## Wiki

Second commit amends the `git_ref` bullet in `wiki/playbooks/build-and-deploy.md`, bumps its timestamp, and adds a `wiki/log.md` entry. `okf index` + `okf check` report 0 errors and 0 warnings across 78 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)