### PR TITLE
Point data-info-next at the completed port

### DIFF
--- a/ansible/roles/services/data-info-next/files/data-info-next.json
+++ b/ansible/roles/services/data-info-next/files/data-info-next.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"harbor.cyverse.org/de/data-info-next","tag":"harbor.cyverse.org/de/data-info-next:golang@sha256:0ec7e9e1e173a2b4295361aa7217a58e9d1f89b68c787c64b4032bbce2f13d4f"}]}
+{"builds":[{"imageName":"harbor.cyverse.org/de/data-info-next","tag":"harbor.cyverse.org/de/data-info-next:golang@sha256:44111eae4601ae1b1d83ae23e611630541de99e8fb6a85c7de31b935e5423e4f"}]}


### PR DESCRIPTION
Updates the `data-info-next` build descriptor to an image built from data-info's `golang`
branch, now that the last twelve unported operations have landed there
(cyverse-de/data-info#105).

Digest `sha256:44111eae4601…`, built and deployed to QA. The deployment still takes no
traffic and the role is still `data_info_next_enabled: false` by default; QA was brought up
with `-e data_info_next_enabled=true`.

## Why this is worth recording

The image serves all 57 operations the Clojure service does — `TestEveryClojureRouteIsServedOrAccountedFor`
reports `57 served, 2 moved to info-typer, 0 not yet ported`. A differential run against the
live QA service reports **174 matching cases and 7 differences**, each one a deliberate
deviation already recorded in the service's `docs/deferred-fixes.md`, with the mapping written
down in `docs/shadow-baseline.md`.

## One thing for whoever looks at the data store

Cases intermittently fail to be *compared at all* because iRODS answers
`ResourceHierarchyException: HIERARCHY_ERROR` when reading a file that was just written. It
hits both services — the Clojure one threw 92 during a single run — and re-reading the same
path afterwards succeeds every time. That is a data-store problem rather than a service one,
and it is worth understanding before the cutover soak, where it would look like intermittent
service failure.

It is **not** the `de-irods` connection limit that held this deployment up. Three concurrent
consumers of that account coexist without trouble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)