### PR TITLE
Harden the portal2 Deployment and record the security-audit deferred items

### DIFF
--- a/ansible/roles/services/portal2/templates/k8s/portal2.yml.j2
+++ b/ansible/roles/services/portal2/templates/k8s/portal2.yml.j2
@@ -36,6 +36,13 @@ spec:
               topologyKey: kubernetes.io/hostname
 {% endif %}
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
 {% include 'partials/de_ca_volume.j2' %}
         - name: config-volume
@@ -48,6 +55,11 @@ spec:
         - name: portal
           image: harbor.cyverse.org/de/portal2
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
 {% include 'partials/de_ca_env.j2' %}
             - name: TZ

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,14 @@
 # Wiki Update Log
 
+## 2026-08-27
+
+* **Update**: [portal2](/services/portal2.md) — recorded the deferred
+  follow-ups from the August 2026 security audit: no CSRF synchronizer token
+  (and logout CSRF via `GET /logout`), per-IP rate limiting that is
+  best-effort because the edge forwards no usable client IP, container
+  hardening without `readOnlyRootFilesystem`, seven dependency advisories
+  needing breaking major bumps, and the inert honeypot fake-field detection.
+
 ## 2026-08-21
 
 * **Update**: [Building and Deploying Services](/playbooks/build-and-deploy.md)

--- a/wiki/services/portal2.md
+++ b/wiki/services/portal2.md
@@ -3,8 +3,8 @@ type: Service
 title: portal2
 description: The CyVerse user portal web application, handling account self-registration, sessions, and service access via Keycloak, portal-conductor, and terrain.
 resource: /ansible/roles/services/portal2
-tags: [portal, user-portal, nodejs, keycloak, accounts]
-timestamp: 2026-07-21T00:00:00Z
+tags: [portal, user-portal, nodejs, keycloak, accounts, security]
+timestamp: 2026-08-27T00:00:00Z
 ---
 
 The CyVerse user portal, a Node.js web application (`NODE_ENV=production`,
@@ -38,6 +38,57 @@ covered by [Bootstrap Portal Admin](/playbooks/bootstrap-portal-admin.md).
 Build and deploy with
 `ansible-playbook -i $INVENTORY deploy_it.yml --tags portal2`; see
 [Building and Deploying Services](/playbooks/build-and-deploy.md).
+
+# Security audit follow-ups (deferred)
+
+A security audit of portal2 shipped in six batches on the `security-audit`
+branch during August 2026. The items below were deliberately **not** fixed and
+remain open.
+
+**CSRF — no synchronizer token.** The app relies on a `SameSite=Lax` session
+cookie plus JSON-only body parsing (Express `bodyParser.json` ignores form
+content-types) to block CSRF, which closes the practical vector. A
+double-submit or per-session token would be defence in depth, but needs the
+frontend to attach a token header to every mutating request. Related and
+low-impact: logout CSRF via `GET /logout` (keycloak-connect) — under `Lax` a
+top-level cross-site navigation still carries the cookie, so a page can
+force-logout a user. Annoyance only; no data exposure.
+
+**Per-IP rate limiting is best-effort.** The in-memory fixed-window limiter on
+the public endpoints keys on Express's `req.ip` with `trust proxy` set to
+`true`. In QA the edge forwards no usable client IP, so `req.ip` resolves to
+cluster-internal addresses that vary per request, and the limiter never reaches
+its budget; it is also per-replica. Making it real needs the edge to forward a
+trustworthy `X-Forwarded-For`, `trust proxy` tightened to the known proxy hop
+rather than any hop, and optionally a shared store (Redis or PostgreSQL) for a
+cross-replica limit. Until then, treat the public rate limits as best-effort
+and do not validate them in QA.
+
+**Container hardening is partial.** The Deployment runs as the image's
+non-root `nodejs` user (uid/gid 1001, matching the Dockerfile) with
+`seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false` and all
+capabilities dropped. It does **not** set `readOnlyRootFilesystem`: the custom
+Next.js server may write `.next/cache` and `/tmp`, so writable `emptyDir`
+mounts must be identified first. Note that a service's own source repo cannot
+supply any of this — `templates/k8s/portal2.yml.j2` here is the only manifest
+that reaches a cluster. It is rendered into `files/k8s/portal2.yml` at deploy
+time (that path is generated and git-ignored), and the build overlays this
+role's `k8s/` and `skaffold.yaml` onto the source worktree, so a
+`k8s/portal2.yml` edited in the portal2 repo is discarded by both paths.
+
+**Seven dependency advisories remain.** A non-breaking `npm audit fix` took the
+count from 28 to 7. The rest need breaking major bumps — `next` (14 to newer,
+which pulls `postcss`), `keycloak-connect` (via `jwk-to-pem` to `elliptic`),
+and the `sequelize`/`uuid` chain — each wanting its own migration and
+regression pass.
+
+**Honeypot fake-field detection is inert.** The `honeypot: true` duplicate-field
+mechanism was never wired up: no code read the flag and the client-side fake id
+was unused. The audit removed the dead code and stopped exposing the divisor to
+the client, but did not revive the detection. Revive it if bot signups become a
+problem. `honeypot.divisor` is still validated at startup and must be a number
+greater than 2.
+
 
 # Citations
 


### PR DESCRIPTION
Follow-ups from the portal2 security audit (the `security-audit` branch in
cyverse-de/portal2), which shipped in six batches deployed to QA.

## Deployment hardening

Adds a `securityContext` to `templates/k8s/portal2.yml.j2`:

- pod: `runAsNonRoot`, uid/gid 1001, `fsGroup` 1001, `seccompProfile: RuntimeDefault`
- container: `allowPrivilegeEscalation: false`, all capabilities dropped

The uid matches the image's own `nodejs` user (`useradd --uid 1001` in the
portal2 Dockerfile), so this asserts the existing behaviour rather than
changing it — the pod already ran as 1001. `readOnlyRootFilesystem` is
deliberately omitted: the custom Next.js server may write `.next/cache` and
`/tmp`, so writable `emptyDir` mounts need to be identified first.

The audit originally added this block to `k8s/portal2.yml` in the portal2 repo,
where it can never take effect: the build overlays this role's `k8s/` and
`skaffold.yaml` onto the source worktree, and the deploy renders this `.j2`
into the (git-ignored) `files/k8s/portal2.yml`. The template here is the only
manifest that reaches a cluster.

## Wiki

Records what the audit deliberately left open, on the existing portal2 page:
no CSRF synchronizer token, best-effort per-IP rate limiting, container
hardening without `readOnlyRootFilesystem`, seven dependency advisories needing
breaking major bumps, and the inert honeypot fake-field detection.

## Verification

Deployed to QA; `deploy/user-portal` rolled out clean, 0 restarts:

```
pod:       {"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}
container: {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}
id → uid=1001(nodejs) gid=1001(nodejs) groups=1001(nodejs)
```

`okf index` + `okf check` report 0 errors and 0 warnings across 79 files.

Not included: `roles/services/portal2/files/portal2.json` is intentionally left
uncommitted while it tracks the `security-audit` branch image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY9cc7crVocPkLUdAKx58w