### PR TITLE
Let the notifications config carry the new SMTP relay settings

### DIFF
--- a/ansible/example/inventory/group_vars/all.yaml
+++ b/ansible/example/inventory/group_vars/all.yaml
@@ -121,6 +121,49 @@
 # Default: replace_me@replace_me.replace_me
 # email_dest: support@cyverse.org
 
+# Relay the notifications service sends the DE's outbound mail through. The
+# defaults point at the in-cluster exim (see local-exim under Phase 4),
+# unauthenticated and in the clear. Set these to send through an external
+# relay directly instead, leaving exim out of the path.
+# Defaults: local-exim / 25
+# notifications_smtp_host: smtp.example.org
+# notifications_smtp_port: 587
+
+# Credentials for a relay that requires SMTP AUTH. Both must be set, or
+# neither; the service refuses to start if only one is. The mechanism is
+# negotiated from what the relay advertises (CRAM-MD5, LOGIN, or PLAIN).
+# Authentication REQUIRES one of the two TLS settings below: Go will not send
+# credentials over an unencrypted connection to a remote host, so a relay
+# configured with a user but no TLS fails at delivery time.
+# Defaults: "" / ""
+# notifications_smtp_user: notifications@example.org
+# notifications_smtp_password: replace_me
+
+# How the connection is encrypted. These are mutually exclusive and the
+# service refuses to start if both are set. Use notifications_smtp_use_tls
+# (STARTTLS) on ports 25 and 587, and notifications_smtp_use_ssl (TLS from the
+# first byte) on port 465. With use_tls set, delivery fails rather than
+# silently falling back to cleartext when the relay will not offer STARTTLS.
+# Defaults: false / false
+# notifications_smtp_use_tls: true
+# notifications_smtp_use_ssl: false
+
+# Name sent in the SMTP HELO. Defaults to the pod's hostname, which is not a
+# fully qualified domain name; set this when the relay rejects or penalizes a
+# HELO name it cannot resolve.
+# Default: ""
+# notifications_smtp_local_name: notifications.example.org
+
+# Certificate verification escape hatches for a relay with a private CA.
+# Neither is usually needed: when de_ca_bundle_configmap is set, the pod
+# already trusts that bundle through SSL_CERT_FILE, which Go honors. Reach for
+# notifications_smtp_ca_cert_file only when the relay's certificate chains to
+# some other authority, and note that the bundle has to be mounted into the
+# pod by separate means for the path to resolve. The two cannot both be set.
+# Defaults: false / ""
+# notifications_smtp_insecure_skip_verify: false
+# notifications_smtp_ca_cert_file: /etc/de-ca/ca.crt
+
 
 # ---------------------------------------------------------------------
 # iRODS

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -358,13 +358,12 @@ exim_allowed_senders: "172.17.0.0/24:127.0.0.1"
 local_exim_replicas: 2
 local_exim_pod_anti_affinity: true
 # Relay the notifications service sends the DE's outbound mail through. The
-# defaults point at the in-cluster exim above, unauthenticated and in the clear,
-# which is how the service behaved before these settings existed. Point them at
-# an external relay to bypass exim; authentication needs one of the TLS settings,
-# since Go refuses to send credentials over an unencrypted connection to a
-# remote host. Leave notifications_smtp_ca_cert_file empty unless the relay's
-# certificate chains to something other than de_ca_bundle_configmap, which the
-# pod already trusts through SSL_CERT_FILE.
+# defaults point at the in-cluster exim above, unauthenticated and in the clear.
+# Point them at an external relay to bypass exim; authentication needs one of
+# the TLS settings, since Go refuses to send credentials over an unencrypted
+# connection to a remote host. Leave notifications_smtp_ca_cert_file empty
+# unless the relay's certificate chains to something other than
+# de_ca_bundle_configmap, which the pod already trusts through SSL_CERT_FILE.
 notifications_smtp_host: local-exim
 notifications_smtp_port: 25
 notifications_smtp_user: ""

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -357,6 +357,23 @@ exim_password: "127.0.0.1"
 exim_allowed_senders: "172.17.0.0/24:127.0.0.1"
 local_exim_replicas: 2
 local_exim_pod_anti_affinity: true
+# Relay the notifications service sends the DE's outbound mail through. The
+# defaults point at the in-cluster exim above, unauthenticated and in the clear,
+# which is how the service behaved before these settings existed. Point them at
+# an external relay to bypass exim; authentication needs one of the TLS settings,
+# since Go refuses to send credentials over an unencrypted connection to a
+# remote host. Leave notifications_smtp_ca_cert_file empty unless the relay's
+# certificate chains to something other than de_ca_bundle_configmap, which the
+# pod already trusts through SSL_CERT_FILE.
+notifications_smtp_host: local-exim
+notifications_smtp_port: 25
+notifications_smtp_user: ""
+notifications_smtp_password: ""
+notifications_smtp_use_tls: false
+notifications_smtp_use_ssl: false
+notifications_smtp_local_name: ""
+notifications_smtp_insecure_skip_verify: false
+notifications_smtp_ca_cert_file: ""
 
 # QMS settings
 qms_enabled: true

--- a/ansible/roles/services/notifications/templates/jobservices.yml.j2
+++ b/ansible/roles/services/notifications/templates/jobservices.yml.j2
@@ -37,7 +37,17 @@ de:
 email:
   request: {{ email_support_dest }}
   fromAddress: {{ email_src }}
-  smtpHost: local-exim
+  # Every smtp* value goes through to_json: a password containing a colon, hash,
+  # or brace would otherwise produce a file that fails to parse or parses wrong.
+  smtpHost: {{ notifications_smtp_host | to_json }}
+  smtpPort: {{ notifications_smtp_port | to_json }}
+  smtpUser: {{ notifications_smtp_user | to_json }}
+  smtpPassword: {{ notifications_smtp_password | to_json }}
+  smtpUseTLS: {{ notifications_smtp_use_tls | bool | to_json }}
+  smtpUseSSL: {{ notifications_smtp_use_ssl | bool | to_json }}
+  smtpLocalName: {{ notifications_smtp_local_name | to_json }}
+  smtpInsecureSkipVerify: {{ notifications_smtp_insecure_skip_verify | bool | to_json }}
+  smtpCACertFile: {{ notifications_smtp_ca_cert_file | to_json }}
 
 external_irods:
   host: "{{ irods_external_host }}"

--- a/ansible/roles/services/notifications/templates/jobservices.yml.j2
+++ b/ansible/roles/services/notifications/templates/jobservices.yml.j2
@@ -37,10 +37,8 @@ de:
 email:
   request: {{ email_support_dest }}
   fromAddress: {{ email_src }}
-  # Every smtp* value goes through to_json: a password containing a colon, hash,
-  # or brace would otherwise produce a file that fails to parse or parses wrong.
   smtpHost: {{ notifications_smtp_host | to_json }}
-  smtpPort: {{ notifications_smtp_port | to_json }}
+  smtpPort: {{ notifications_smtp_port | int | to_json }}
   smtpUser: {{ notifications_smtp_user | to_json }}
   smtpPassword: {{ notifications_smtp_password | to_json }}
   smtpUseTLS: {{ notifications_smtp_use_tls | bool | to_json }}

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,19 @@
 # Wiki Update Log
 
+## 2026-08-28
+
+* **Update**: [notifications](/services/notifications.md) — the service gained
+  `email.smtp*` settings for reaching authenticated and TLS-only relays, so
+  `smtpHost` is no longer hardcoded to `local-exim`. Added a "Reaching the
+  relay" section covering the new `notifications_smtp_*` inventory variables,
+  the two mutually exclusive pairs the service rejects at startup, why
+  authentication requires one of the TLS settings, and why certificate
+  verification usually needs nothing configured given `SSL_CERT_FILE`.
+* **Update**: [Miscellaneous Utility Playbooks](/playbooks/misc-utility-playbooks.md)
+  — local-exim is now the default path for outbound DE mail rather than the
+  only one, since `notifications_smtp_*` can point notifications at an external
+  relay directly.
+
 ## 2026-08-27
 
 * **Update**: [portal2](/services/portal2.md) — recorded the deferred

--- a/wiki/playbooks/misc-utility-playbooks.md
+++ b/wiki/playbooks/misc-utility-playbooks.md
@@ -4,7 +4,7 @@ title: Miscellaneous Utility Playbooks
 description: A catalog of the small standalone playbooks - security mitigations, k3s-era cleanup, host surveys, database copies, config pushes, app imports, and GoCD kubeconfig transfer.
 resource: /ansible
 tags: [utilities, playbooks, maintenance, mitigations]
-timestamp: 2026-07-30T00:00:00Z
+timestamp: 2026-08-28T00:00:00Z
 ---
 
 Small standalone playbooks that don't fit a larger workflow. Node updates and
@@ -67,8 +67,9 @@ Deploys the `local-exim` mail relay on its own — the standalone equivalent of
 the local-exim slice of `--tags de-reqs`, which otherwise also re-runs the
 namespace, cert-issuer, timezone, and Harbor pull-secret tasks. It imports the
 same task file the `k8s_de_reqs` role uses, so the two paths cannot drift.
-[notifications](/services/notifications.md) relays all outbound DE mail through
-this deployment. The play first asserts that `exim_smarthost` is set and does not
+[notifications](/services/notifications.md) relays outbound DE mail through this
+deployment by default, though its `notifications_smtp_*` settings can point it
+at an external relay directly and leave exim out of the path. The play first asserts that `exim_smarthost` is set and does not
 point at loopback: the role default does, which makes exim smarthost to itself
 and silently drops every message. Note that the value is an exim host list, so
 a port needs a second colon (`host::port`).

--- a/wiki/playbooks/misc-utility-playbooks.md
+++ b/wiki/playbooks/misc-utility-playbooks.md
@@ -69,10 +69,11 @@ namespace, cert-issuer, timezone, and Harbor pull-secret tasks. It imports the
 same task file the `k8s_de_reqs` role uses, so the two paths cannot drift.
 [notifications](/services/notifications.md) relays outbound DE mail through this
 deployment by default, though its `notifications_smtp_*` settings can point it
-at an external relay directly and leave exim out of the path. The play first asserts that `exim_smarthost` is set and does not
-point at loopback: the role default does, which makes exim smarthost to itself
-and silently drops every message. Note that the value is an exim host list, so
-a port needs a second colon (`host::port`).
+at an external relay directly and leave exim out of the path. The play first
+asserts that `exim_smarthost` is set and does not point at loopback: the role
+default does, which makes exim smarthost to itself and silently drops every
+message. Note that the value is an exim host list, so a port needs a second
+colon (`host::port`).
 
 ## openldap_community_group.yml
 

--- a/wiki/services/notifications.md
+++ b/wiki/services/notifications.md
@@ -4,7 +4,7 @@ title: notifications
 description: User notifications service backed by the DE database, reached by other services at http://notifications/v1; also records the notification events it publishes and sends the resulting email, roles absorbed from the retired event-recorder and de-mailer.
 resource: /ansible/roles/services/notifications
 tags: [notifications, postgresql, amqp, rabbitmq, jobservices, events, email, smtp]
-timestamp: 2026-08-18T00:00:00Z
+timestamp: 2026-08-28T00:00:00Z
 ---
 
 notifications stores and serves DE user notifications. Its config points at the
@@ -96,15 +96,47 @@ Message bodies are rendered from templates shipped in the image under
 `/app/templates/{html,text}`, selected by the request's template name and
 preferring the HTML version. The merge added the `de:` config block (the DE
 base URL plus the UI path fragments used to build links in email bodies) and
-two settings under `email:` — `fromAddress` (`email_src`) and `smtpHost`
-(hardcoded to `local-exim`). All of `email.fromAddress`, `email.smtpHost`, and
-`de.base` are validated at startup alongside the existing required settings,
-so a missing one fails the deployment rather than failing every send.
+the `email:` settings that describe the relay. All of `email.fromAddress`,
+`email.smtpHost`, and `de.base` are validated at startup alongside the existing
+required settings, so a missing one fails the deployment rather than failing
+every send.
 
 Failed AMQP deliveries are logged with their cause and acked (dropped),
 matching the retired service's behavior. On `SIGTERM` the service drains
 in-flight deliveries before closing the connection, so mail that was already
 sent isn't requeued and sent again on the next rolling deploy.
+
+### Reaching the relay
+
+`smtpHost` defaults to `local-exim` (below), but the service is not limited to
+it. The `notifications_smtp_*` inventory variables map onto the service's
+`email.smtp*` settings and cover what a relay is likely to demand: a port other
+than 25 (`notifications_smtp_port`), SMTP AUTH (`notifications_smtp_user` and
+`notifications_smtp_password`, with the mechanism negotiated from what the
+relay advertises), STARTTLS (`notifications_smtp_use_tls`) or implicit TLS
+(`notifications_smtp_use_ssl`), and the HELO name
+(`notifications_smtp_local_name`, defaulting to the pod's hostname). Pointing
+them at an external relay takes local-exim out of the delivery path entirely;
+leaving them at their defaults keeps it.
+
+Two constraints bite in practice. Authentication needs one of the TLS settings:
+Go refuses to send credentials over an unencrypted connection to a remote host,
+so a user configured without TLS fails at delivery time rather than at startup.
+And the two TLS settings are mutually exclusive — STARTTLS upgrades a cleartext
+connection, implicit TLS is encrypted from the first byte — as are
+`notifications_smtp_insecure_skip_verify` and
+`notifications_smtp_ca_cert_file`. Both pairs are validated at startup, so a
+contradictory inventory fails the deployment instead of every send.
+
+Certificate verification usually needs nothing configured: when
+`de_ca_bundle_configmap` is set, the pod already trusts that bundle through
+`SSL_CERT_FILE`, which Go honors for the system roots.
+`notifications_smtp_ca_cert_file` is only for a relay whose certificate chains
+to some other authority, and that bundle has to be mounted into the pod by
+separate means for the path to resolve.
+
+With `notifications_smtp_use_tls` set, a relay that will not offer STARTTLS is
+an error rather than a silent fallback to cleartext.
 
 ### The local-exim relay
 
@@ -147,7 +179,9 @@ mounted at `/etc/iplant/de/jobservices.yml`. The operative section is
 `dbms_connection_pass`, `groups['dbms'][0]`, `pg_listen_port`, and `de_db_name`
 — the key is named for the service, not for the database it points at; the AMQP
 URI comes from the `de_amqp_*` group_vars.
-The `de:` and `email:` blocks drive outbound mail. The rest of the shared
+The `de:` and `email:` blocks drive outbound mail; every `email.smtp*` value is
+rendered through `to_json`, so a password containing a colon or hash cannot
+break the file. The rest of the shared
 template (Condor, iRODS, VICE, Keycloak, Harbor) is common boilerplate across
 the job services. Defaults: `notifications_replicas: 2` with required pod
 anti-affinity.
@@ -165,7 +199,7 @@ See [Building and Deploying Services](/playbooks/build-and-deploy.md).
 1. `ansible/roles/services/notifications/templates/jobservices.yml.j2` — notifications DB URI, AMQP configuration, `email.request`, and the `de:`/`email:` blocks that drive outbound mail.
 2. `ansible/roles/services/notifications/templates/k8s/notifications.yml.j2` — Deployment/Service, port 8080, `OTEL_TRACES_EXPORTER=none`.
 3. `ansible/roles/services/notifications/files/notifications.json` — image and pinned tag/digest.
-4. `ansible/roles/common/defaults/main.yml` — `notifications_db_name`, `baseurls_notifications`, `baseurls_iplant_email`, `email_support_dest`, `email_src`, `source_repos` entry, and the placeholder `exim_*` defaults.
+4. `ansible/roles/common/defaults/main.yml` — `notifications_db_name`, `baseurls_notifications`, `baseurls_iplant_email`, `email_support_dest`, `email_src`, the `notifications_smtp_*` relay defaults, `source_repos` entry, and the placeholder `exim_*` defaults.
 5. `ansible/roles/services/notifications/tasks/main.yml` — creates the `notifications-configs` Secret and removes the retired event-recorder and de-mailer objects.
 6. `ansible/roles/k8s_de_reqs/tasks/local_exim.yml` — the local-exim Deployment and Service, and how `EXIM_ALLOWED_SENDERS` is assembled from the cluster CIDRs.
 7. `ansible/local-exim.yml` — standalone local-exim run with the smarthost assertion.


### PR DESCRIPTION
notifications gained `email.smtp*` settings for reaching authenticated and TLS-only relays (cyverse-de/notifications#15), but the template hardcoded `smtpHost` to `local-exim` and emitted nothing else, so no deployment could use them.

## Changes

Nine `notifications_smtp_*` defaults in `roles/common/defaults/main.yml`, in the existing `## Email settings` section next to the `exim_*` settings they may bypass. Every default reproduces current behavior, so an existing deployment renders a config that means exactly what it means today.

The `email:` block in the notifications role's `jobservices.yml.j2` emits all nine, unconditionally, matching how every other block in that file is written. The password lands in `jobservices.yml`, which the role already stores as a Kubernetes Secret alongside the DB, AMQP, Keycloak, and iRODS passwords, so no new secret handling is needed.

Every value goes through `to_json` — the idiom `data-info-next/templates/data-info.yml.j2` already documents. A password containing a colon, hash, or brace would otherwise render a `jobservices.yml` that fails to parse or, worse, parses wrong.

The settings are documented in the example inventory, and `wiki/services/notifications.md` gains a "Reaching the relay" section.

## On `notifications_smtp_ca_cert_file`

Exposed but not self-sufficient: nothing mounts an arbitrary CA bundle into the pod, so the path only resolves if an operator arranges that separately. Deliberately not building a configmap-and-mount mechanism for it, since the common case needs nothing — when `de_ca_bundle_configmap` is set the pod already trusts that bundle through `SSL_CERT_FILE`, which Go honors for the system roots. Documented in both places.

## Testing

Rendered the template with `ansible-playbook` under three variable sets — defaults, an authenticated STARTTLS relay, and a password containing `: # { } ' "` — asserting each parses as YAML and carries the right values and types (`smtpPort` an int, `smtpUseTLS` a real bool). Confirmed the `to_json` is load-bearing by stripping it and watching the render become unparseable.

Deployed to QA and verified end to end: mail delivered directly to the external relay with local-exim bypassed.

Two stale wiki claims corrected — the notifications page said `smtpHost` was "hardcoded to `local-exim`", and the local-exim playbook page said notifications relays *all* outbound DE mail through it. Both are defaults now, not facts. `okf check`: 0 errors, 0 warnings across 79 files.