### PR TITLE
documented that source checkouts must have origin pointing at cyverse-de

### DIFF
--- a/ansible/BUILD_DEPLOY.md
+++ b/ansible/BUILD_DEPLOY.md
@@ -53,6 +53,43 @@ expected as siblings of this repo:
 `<source_repo_dir>/<service>` and can be overridden with `source_repo` when a
 checkout lives elsewhere or under a different name.
 
+### Checkouts must have `origin` pointing at `cyverse-de`
+
+Cloning and building assume each checkout's `origin` remote is the canonical
+`cyverse-de` repository. Both roles fetch from `origin` by name, and a ref that
+doesn't resolve locally is retried as `origin/<ref>`. There is no `upstream`
+handling and no variable for the remote name.
+
+A fork-based development checkout — `origin` pointing at your fork and
+`upstream` at `cyverse-de` — therefore builds from the fork:
+
+- Release tags cut in `cyverse-de` after the fork was created don't exist in
+  `origin`, so the fetch won't bring them in and `build_release.yml` fails on
+  them with `git_ref <tag> names no commit`.
+- A branch name resolves to your *local* branch before anything remote is
+  consulted, so the build gets whatever that branch points at, including
+  unpushed work.
+- Both fetches are best-effort and never fail the run, so this surfaces as a
+  stale build or a missing-ref error rather than as a wrong-remote error.
+
+Keep deployment checkouts separate from fork-based development checkouts, and
+point `source_repo_dir` at them:
+
+```bash
+ansible-playbook clone_sources.yml -e source_repo_dir=/path/to/de-deploy
+ansible-playbook -i "$QA_INVENTORY" build_it.yml --tags terrain \
+  -e source_repo_dir=/path/to/de-deploy
+```
+
+`source_repo_dir` has to be passed on every build and release run — there is no
+inventory-level place it is set. `source_repo` does the same for a single
+service, if you do want one built from a development checkout.
+
+Builds themselves are non-destructive to a checkout: they add a detached
+worktree in a temp directory and remove it afterwards, leaving your branches and
+working tree alone. An interrupted run can leave a stale worktree entry behind
+(`git worktree prune` clears it).
+
 ## Prerequisites
 
 - **Docker** with **BuildKit** available, and **skaffold** on `PATH`.
@@ -84,7 +121,9 @@ ansible-playbook clone_sources.yml
 ```
 
 - Already-cloned repos are left untouched, but their tags/branches are refreshed
-  (`git fetch --tags`) since releases build from tags.
+  (`git fetch --tags --force origin`) since releases build from tags. The fetch
+  is from `origin`, which must be the `cyverse-de` repository — see
+  [Checkouts must have `origin` pointing at `cyverse-de`](#checkouts-must-have-origin-pointing-at-cyverse-de).
 - All repos live under the `cyverse-de` org. `source_repo_urls` exists for
   per-repo exceptions and is currently empty.
 - Clones default to SSH (`git@github.com:cyverse-de`), so a GitHub SSH key must
@@ -139,8 +178,10 @@ For each selected service the `build-service` role:
 1. Asserts the source repo exists at `source_repo` (fails with guidance if not).
 2. Creates a temporary git **worktree** checked out at `git_ref` — the source
    checkout itself is never modified.
-3. `git fetch --tags` first, so a requested release tag resolves even if the
-   clone is stale.
+3. `git fetch --tags --force origin` first, so a requested release tag resolves
+   even if the clone is stale, then resolves `git_ref` to a commit — as a local
+   ref if possible, otherwise as `origin/<ref>`. Both steps go through `origin`,
+   which must be the `cyverse-de` repository.
 4. Overlays the service role's `skaffold.yaml`, `k8s/`, and the shared
    `buildx-build.sh` onto the worktree.
 5. Rewrites `harbor.cyverse.org` in the overlaid skaffold config to
@@ -251,6 +292,11 @@ Release builds use git tags. If a tag isn't found, the local clone is likely
 stale — re-run `clone_sources.yml` (which fetches tags for existing checkouts),
 or `git fetch --tags` in the source repo. Builds fetch tags automatically before
 checkout, so this is usually a clone that predates that behavior.
+
+The other cause is a checkout whose `origin` is a fork rather than
+`cyverse-de`: the tag was never pushed to the fork, so no fetch will find it.
+Check `git remote -v` in the source repo — see
+[Checkouts must have `origin` pointing at `cyverse-de`](#checkouts-must-have-origin-pointing-at-cyverse-de).
 
 ### An upstream build is broken
 

--- a/ansible/clone_sources.yml
+++ b/ansible/clone_sources.yml
@@ -12,6 +12,12 @@
 # Cloning over SSH needs a configured GitHub SSH key. For HTTPS instead, set
 # -e cyverse_repo_base=https://github.com/cyverse-de (and a credential helper
 # such as `gh auth setup-git` for private repos).
+#
+# Already-cloned repos are only re-fetched, from their `origin` remote, which is
+# assumed to be the cyverse-de repository. A fork-based development checkout
+# (origin = your fork, upstream = cyverse-de) will not pick up release tags cut
+# after the fork; point source_repo_dir at a separate deployment checkout
+# instead. See BUILD_DEPLOY.md.
 
 ---
 - name: clone the cyverse source repositories

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,16 @@
 # Wiki Update Log
 
+## 2026-09-01
+
+* **Update**: [Building and Deploying Services](/playbooks/build-and-deploy.md)
+  — documented that cloning and building both assume a checkout's `origin`
+  remote is the `cyverse-de` repository. Added a "Fork checkouts build from the
+  fork" section: `source_repo_dir` defaults to the directory containing this
+  repo, so a fork-based development tree is picked up by default, where missing
+  upstream release tags and locally-resolved branch refs make builds fail or
+  build the wrong tree. `ansible/BUILD_DEPLOY.md` and `ansible/clone_sources.yml`
+  gained the same warning.
+
 ## 2026-08-28
 
 * **Update**: [notifications](/services/notifications.md) — the service gained

--- a/wiki/playbooks/build-and-deploy.md
+++ b/wiki/playbooks/build-and-deploy.md
@@ -4,7 +4,7 @@ title: Building and Deploying Services
 description: How service container images are built from source with build_it.yml and build_release.yml, and deployed with deploy_it.yml.
 resource: /ansible/BUILD_DEPLOY.md
 tags: [build, deploy, release, skaffold, ansible]
-timestamp: 2026-08-21T22:27:54Z
+timestamp: 2026-09-01T00:00:00Z
 ---
 
 This repo is the source of truth for build and deploy configuration: each
@@ -55,6 +55,8 @@ ansible-playbook -i "$QA_INVENTORY" deploy_it.yml --tags app-exposer
   exists only on the remote — it is resolved to a commit, falling back to
   `origin/<ref>`, before the worktree is made, so no local branch is created in
   the checkout. A ref that resolves to neither fails by name.
+* Both cloning and building assume each checkout's `origin` remote is the
+  `cyverse-de` repository — see [Fork checkouts build from the fork](#fork-checkouts-build-from-the-fork).
 * Builds write descriptors into the service role's own `files/` directory, and
   deploys read from `build_json_dir`, which resolves to that same directory. If
   a freshly built image isn't picked up on deploy, the build most likely never
@@ -104,8 +106,27 @@ unchanged service genuinely untouched. Keep any such value distinct per
 service: skaffold scopes `--status-check` by this label, so one value shared
 across services makes each deploy wait on all of them.
 
+## Fork checkouts build from the fork
+
+`clone_sources.yml` and the build role both fetch from `origin` by name, and a
+`git_ref` that doesn't resolve locally is retried as `origin/<ref>`. Neither
+knows about an `upstream` remote, and the remote name isn't a variable. Since
+`source_repo_dir` defaults to the directory containing this repo, a fork-based
+development tree sitting alongside it is picked up by default.
+
+In that tree `origin` is the fork, so release tags cut in `cyverse-de` after the
+fork was created are absent and `build_release.yml` fails on them with
+`names no commit`; a branch ref resolves to the local branch, unpushed work
+included. Both fetches are best-effort (`failed_when: false`), so the symptom is
+a stale build or a missing ref rather than a wrong-remote error.
+
+Keep deployment checkouts separate from development ones and pass
+`-e source_repo_dir=<dir>` on every clone, build, and release run — there is no
+inventory-level place it is set. `-e source_repo=<path>` overrides one service.
+
 # Citations
 
 [1] `ansible/BUILD_DEPLOY.md` — source document: full prerequisites, what a build does step by step, all variables, troubleshooting.
 [2] `ansible/roles/build-service/`, `ansible/roles/deploy-service/` — the roles that implement builds and deploys.
 [3] `ansible/deploy_it.yml` — the service list, and the post-run wait and failure report driven by `deploy_wait` / `deploy_continue_on_error`.
+[4] `ansible/clone_sources.yml`, `ansible/roles/clone-sources/` — the clone playbook and role, including the `git fetch --tags --force origin` refresh of existing checkouts.


### PR DESCRIPTION
Cloning and building both fetch from `origin` by name and resolve an unresolvable git_ref as `origin/<ref>`; neither knows about an `upstream` remote. Since source_repo_dir defaults to the directory containing this repo, a fork-based development tree alongside it is picked up by default and builds from the fork -- missing upstream release tags and locally-resolved branch refs make builds fail or build the wrong tree, quietly, since both fetches are best-effort.

Added a concepts section to BUILD_DEPLOY.md covering the assumption, the failure modes, and the source_repo_dir workaround; noted the origin fetch in the cloning bullet, the build steps, and the release-tag troubleshooting entry; repeated the warning in the clone_sources.yml header; and brought the wiki page along.


Claude-Session: https://claude.ai/code/session_018r38VoLnhVMLM74iwdpi2C